### PR TITLE
Migrate to Fly.io with SSR and preview deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+.git
+.github
+.gitignore
+.env*
+.DS_Store
+out
+.vercel
+.serena
+.playwright-mcp
+screenshots
+*.md

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Site URL (used in RSS feed, meta tags)
+NEXT_PUBLIC_SITE_URL=https://afterwords.gr
+
+# Google Analytics Measurement ID
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-5NHQFR2NKS
+
+# HelpScout Beacon ID
+NEXT_PUBLIC_HELPSCOUT_BEACON_ID=59d3cf5c-2a28-4cd5-a299-7cc71501140d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Production
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: |
+          flyctl deploy --remote-only \
+            --build-arg NEXT_PUBLIC_SITE_URL=${{ vars.SITE_URL }} \
+            --build-arg NEXT_PUBLIC_GA_MEASUREMENT_ID=${{ secrets.GA_MEASUREMENT_ID }} \
+            --build-arg NEXT_PUBLIC_HELPSCOUT_BEACON_ID=${{ secrets.HELPSCOUT_BEACON_ID }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npx next lint
+        run: npm run lint
 
       - name: Type check
         run: npx tsc --noEmit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
-
       - name: Type check
         run: npx tsc --noEmit
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,36 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  checks:
+    name: Lint, Type Check & Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npx next lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_SITE_URL: https://afterwords.gr
+
   deploy:
     name: Deploy Production
+    needs: checks
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,8 +13,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  checks:
+    name: Lint, Type Check & Build
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npx next lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_SITE_URL: https://afterwords.gr
+
   preview-deploy:
     name: Deploy Preview
+    needs: checks
     if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -41,8 +41,6 @@ jobs:
 
           flyctl deploy --remote-only \
             --app "$APP_NAME" \
-            --region ams \
-            --vm-memory 256 \
             --build-arg NEXT_PUBLIC_SITE_URL=https://pr-${PR_NUMBER}.preview.afterwords.gr \
             --build-arg NEXT_PUBLIC_GA_MEASUREMENT_ID=${{ secrets.GA_MEASUREMENT_ID }} \
             --build-arg NEXT_PUBLIC_HELPSCOUT_BEACON_ID=${{ secrets.HELPSCOUT_BEACON_ID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,96 @@
+name: Preview Deployment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview-deploy:
+    name: Deploy Preview
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment:
+      name: preview-pr-${{ github.event.pull_request.number }}
+      url: https://pr-${{ github.event.pull_request.number }}.preview.afterwords.gr
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Create or deploy preview app
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          APP_NAME: afterwords-preview-pr-${{ github.event.pull_request.number }}
+        run: |
+          # Create app if it doesn't exist
+          if ! flyctl apps list | grep -q "$APP_NAME"; then
+            flyctl apps create "$APP_NAME" --org personal
+            flyctl certs create --app "$APP_NAME" "pr-${PR_NUMBER}.preview.afterwords.gr"
+          fi
+
+          flyctl deploy --remote-only \
+            --app "$APP_NAME" \
+            --region ams \
+            --vm-memory 256 \
+            --build-arg NEXT_PUBLIC_SITE_URL=https://pr-${PR_NUMBER}.preview.afterwords.gr \
+            --build-arg NEXT_PUBLIC_GA_MEASUREMENT_ID=${{ secrets.GA_MEASUREMENT_ID }} \
+            --build-arg NEXT_PUBLIC_HELPSCOUT_BEACON_ID=${{ secrets.HELPSCOUT_BEACON_ID }}
+
+      - name: Comment PR with preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = `https://pr-${prNumber}.preview.afterwords.gr`;
+            const body = `🔗 **Preview deployment ready!**\n\n${previewUrl}\n\n_Deployed from commit ${context.sha.substring(0, 7)}_`;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const botComment = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Preview deployment ready')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  preview-destroy:
+    name: Destroy Preview
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Destroy preview app
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          APP_NAME: afterwords-preview-pr-${{ github.event.pull_request.number }}
+        run: flyctl apps destroy "$APP_NAME" --yes || true
+        continue-on-error: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npx next lint
+        run: npm run lint
 
       - name: Type check
         run: npx tsc --noEmit

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
-
       - name: Type check
         run: npx tsc --noEmit
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: preview-pr-${{ github.event.pull_request.number }}
-      url: https://pr-${{ github.event.pull_request.number }}.preview.afterwords.gr
+      url: https://afterwords-preview-pr-${{ github.event.pull_request.number }}.fly.dev
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,12 +36,11 @@ jobs:
           # Create app if it doesn't exist
           if ! flyctl apps list | grep -q "$APP_NAME"; then
             flyctl apps create "$APP_NAME" --org personal
-            flyctl certs create --app "$APP_NAME" "pr-${PR_NUMBER}.preview.afterwords.gr"
           fi
 
           flyctl deploy --remote-only \
             --app "$APP_NAME" \
-            --build-arg NEXT_PUBLIC_SITE_URL=https://pr-${PR_NUMBER}.preview.afterwords.gr \
+            --build-arg NEXT_PUBLIC_SITE_URL=https://${APP_NAME}.fly.dev \
             --build-arg NEXT_PUBLIC_GA_MEASUREMENT_ID=${{ secrets.GA_MEASUREMENT_ID }} \
             --build-arg NEXT_PUBLIC_HELPSCOUT_BEACON_ID=${{ secrets.HELPSCOUT_BEACON_ID }}
 
@@ -50,7 +49,7 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
-            const previewUrl = `https://pr-${prNumber}.preview.afterwords.gr`;
+            const previewUrl = `https://afterwords-preview-pr-${prNumber}.fly.dev`;
             const body = `🔗 **Preview deployment ready!**\n\n${previewUrl}\n\n_Deployed from commit ${context.sha.substring(0, 7)}_`;
 
             const comments = await github.rest.issues.listComments({

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# --- Stage 1: Dependencies ---
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+# --- Stage 2: Build ---
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+ARG NEXT_PUBLIC_SITE_URL=https://afterwords.gr
+ARG NEXT_PUBLIC_GA_MEASUREMENT_ID
+ARG NEXT_PUBLIC_HELPSCOUT_BEACON_ID
+
+ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL
+ENV NEXT_PUBLIC_GA_MEASUREMENT_ID=$NEXT_PUBLIC_GA_MEASUREMENT_ID
+ENV NEXT_PUBLIC_HELPSCOUT_BEACON_ID=$NEXT_PUBLIC_HELPSCOUT_BEACON_ID
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN npm run build
+
+# --- Stage 3: Runner ---
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+# Blog content needed at runtime for MDX loading via fs.readFileSync
+COPY --from=builder /app/src/content ./src/content
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,0 +1,334 @@
+# Deployment Guide — afterwords.gr on Fly.io
+
+This guide covers the full setup, deployment, DNS configuration, and ongoing operations for the Afterwords website hosted on Fly.io.
+
+## Architecture Overview
+
+```
+GitHub repo (main branch)
+  │
+  ├─ push to main ──→ GitHub Actions ──→ fly deploy ──→ afterwords.gr (production)
+  │
+  ├─ PR opened ─────→ GitHub Actions ──→ fly deploy ──→ pr-<N>.preview.afterwords.gr
+  │
+  └─ PR closed ─────→ GitHub Actions ──→ fly destroy ──→ preview app removed
+```
+
+- **Runtime:** Next.js standalone (SSR) in a Docker container
+- **Region:** Amsterdam (`ams`) — optimized for Greek/EU audience
+- **Scaling:** Auto-stop when idle, auto-start on request. Stopped machines cost nothing.
+
+## Initial Setup (One-Time)
+
+### 1. Install the Fly CLI
+
+```bash
+brew install flyctl
+```
+
+### 2. Authenticate
+
+```bash
+fly auth login
+```
+
+### 3. Create the Fly app
+
+```bash
+fly apps create afterwords-web
+```
+
+### 4. Allocate IP addresses
+
+```bash
+fly ips allocate-v4 --shared -a afterwords-web
+fly ips allocate-v6 -a afterwords-web
+```
+
+Note the IPs — you'll need them for DNS:
+
+```bash
+fly ips list -a afterwords-web
+```
+
+### 5. Set Fly secrets
+
+These are available as runtime environment variables inside the container:
+
+```bash
+fly secrets set \
+  NEXT_PUBLIC_SITE_URL=https://afterwords.gr \
+  NEXT_PUBLIC_GA_MEASUREMENT_ID=G-5NHQFR2NKS \
+  NEXT_PUBLIC_HELPSCOUT_BEACON_ID=59d3cf5c-2a28-4cd5-a299-7cc71501140d \
+  -a afterwords-web
+```
+
+### 6. Configure GitHub repository
+
+Go to **Settings → Secrets and variables → Actions** in the GitHub repo.
+
+**Secrets** (sensitive, masked in logs):
+
+| Name | Value | How to get it |
+|------|-------|---------------|
+| `FLY_API_TOKEN` | Fly.io org deploy token | `fly tokens create org` |
+| `GA_MEASUREMENT_ID` | `G-5NHQFR2NKS` | Google Analytics |
+| `HELPSCOUT_BEACON_ID` | `59d3cf5c-2a28-4cd5-a299-7cc71501140d` | HelpScout dashboard |
+
+**Variables** (non-sensitive, visible in logs):
+
+| Name | Value |
+|------|-------|
+| `SITE_URL` | `https://afterwords.gr` |
+
+### 7. Create the production environment
+
+Go to **Settings → Environments → New environment**:
+- Name: `production`
+- Deployment branches: restrict to `main` only
+
+This ensures only pushes to `main` can trigger production deployments.
+
+## DNS Configuration (Papaki.gr)
+
+### Step 1: Register custom domains with Fly
+
+```bash
+fly certs create afterwords.gr -a afterwords-web
+fly certs create www.afterwords.gr -a afterwords-web
+```
+
+Fly will provision Let's Encrypt TLS certificates automatically once DNS is pointed.
+
+### Step 2: Check certificate status
+
+```bash
+fly certs show afterwords.gr -a afterwords-web
+```
+
+Wait until it shows `Ready`. This happens automatically once DNS propagates.
+
+### Step 3: Configure DNS records at Papaki.gr
+
+**Production (afterwords.gr):**
+
+| Type | Name | Value | TTL |
+|------|------|-------|-----|
+| A | `@` | *(Fly IPv4 from step 4 above)* | 300 |
+| AAAA | `@` | *(Fly IPv6 from step 4 above)* | 300 |
+| CNAME | `www` | `afterwords.gr` | 300 |
+
+**Preview deployments (*.preview.afterwords.gr):**
+
+| Type | Name | Value | TTL |
+|------|------|-------|-----|
+| A | `*.preview` | *(same Fly IPv4)* | 300 |
+| AAAA | `*.preview` | *(same Fly IPv6)* | 300 |
+
+The wildcard record routes all `pr-<N>.preview.afterwords.gr` traffic to Fly, which matches by hostname (SNI) to the correct preview app.
+
+### Cutover strategy
+
+1. Lower TTL on existing DNS records to 300s
+2. Wait for the old TTL to expire (check with `dig afterwords.gr`)
+3. Replace the records with the Fly IPs
+4. Verify: `curl -I https://afterwords.gr`
+5. Once confirmed, disable GitHub Pages in repo settings
+
+## Deploying
+
+### Production
+
+Push or merge to `main`. That's it. The `deploy.yml` workflow:
+
+1. Checks out the code
+2. Builds the Docker image on Fly's remote builders
+3. Deploys to the `afterwords-web` app
+
+Monitor in real time:
+
+```bash
+fly logs -a afterwords-web
+```
+
+Or check the GitHub Actions tab for build logs.
+
+### Preview deployments
+
+Open a pull request. The `preview.yml` workflow:
+
+1. Creates a Fly app named `afterwords-preview-pr-<N>` (if it doesn't exist)
+2. Provisions a TLS cert for `pr-<N>.preview.afterwords.gr`
+3. Builds and deploys
+4. Comments on the PR with the preview URL
+
+When the PR is closed or merged, the preview app is automatically destroyed.
+
+## Operations
+
+### View logs
+
+```bash
+# Production
+fly logs -a afterwords-web
+
+# Preview app
+fly logs -a afterwords-preview-pr-42
+```
+
+### Check app status
+
+```bash
+fly status -a afterwords-web
+```
+
+### SSH into a running machine
+
+```bash
+fly ssh console -a afterwords-web
+```
+
+### Restart the app
+
+```bash
+fly apps restart afterwords-web
+```
+
+### Scale up (if needed)
+
+```bash
+# Keep one machine always running (eliminates cold starts)
+fly scale count 1 --app afterwords-web
+
+# Increase memory
+fly scale memory 512 --app afterwords-web
+```
+
+To revert to auto-stop behavior, set `min_machines_running = 0` in `fly.toml` and redeploy.
+
+### View allocated IPs
+
+```bash
+fly ips list -a afterwords-web
+```
+
+### Manage TLS certificates
+
+```bash
+# List certificates
+fly certs list -a afterwords-web
+
+# Check certificate status
+fly certs show afterwords.gr -a afterwords-web
+
+# Add a new domain
+fly certs create subdomain.afterwords.gr -a afterwords-web
+
+# Remove a domain
+fly certs remove subdomain.afterwords.gr -a afterwords-web
+```
+
+### Manage secrets
+
+```bash
+# List secret names (values are never shown)
+fly secrets list -a afterwords-web
+
+# Set or update a secret
+fly secrets set KEY=value -a afterwords-web
+
+# Remove a secret
+fly secrets unset KEY -a afterwords-web
+```
+
+Changing a secret triggers an automatic redeployment.
+
+### Clean up stuck preview apps
+
+If a preview app wasn't destroyed (e.g., workflow failure):
+
+```bash
+# List all apps
+fly apps list
+
+# Manually destroy
+fly apps destroy afterwords-preview-pr-42 --yes
+```
+
+## Environment Variables Reference
+
+| Variable | Used in | Purpose | Set where |
+|----------|---------|---------|-----------|
+| `NEXT_PUBLIC_SITE_URL` | RSS feed, meta tags | Canonical site URL | Fly secrets + GH Actions variable |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | Root layout | Google Analytics tracking | Fly secrets + GH Actions secret |
+| `NEXT_PUBLIC_HELPSCOUT_BEACON_ID` | Root layout | HelpScout chat widget | Fly secrets + GH Actions secret |
+
+All `NEXT_PUBLIC_*` variables are inlined at build time by Next.js. They are passed as Docker build args in GitHub Actions. The Fly secrets serve as a fallback for any server-side runtime usage.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `fly.toml` | Fly.io app configuration (region, scaling, health checks) |
+| `Dockerfile` | Multi-stage Docker build for Next.js standalone |
+| `.dockerignore` | Files excluded from Docker build context |
+| `.env.example` | Documents required environment variables |
+| `.github/workflows/deploy.yml` | Production deployment workflow |
+| `.github/workflows/preview.yml` | PR preview deployment workflow |
+
+## Costs (Fly.io)
+
+With `auto_stop_machines = "stop"` and `min_machines_running = 0`:
+
+- **Idle:** $0 (stopped machines are free)
+- **Active (shared-cpu-1x, 256MB):** ~$1.94/month if running 24/7
+- **Bandwidth:** 100GB/month free outbound, then $0.02/GB
+- **Remote builder:** free tier covers small projects
+
+For a low-traffic site, expect **$3–5/month** total.
+
+## Troubleshooting
+
+### Build fails in GitHub Actions
+
+Check the Actions tab for logs. Common issues:
+- Missing `FLY_API_TOKEN` secret
+- npm dependency issues (try `npm ci` locally first)
+- Docker build errors (test locally with `docker build .`)
+
+### Site returns 502
+
+The machine might be starting up (cold start). Wait 2-3 seconds and retry. If persistent:
+
+```bash
+fly logs -a afterwords-web
+fly status -a afterwords-web
+```
+
+### TLS certificate not provisioning
+
+```bash
+fly certs show afterwords.gr -a afterwords-web
+```
+
+Ensure DNS records point to Fly IPs. Certificate provisioning requires DNS to be correctly configured. It uses HTTP-01 validation, so the domain must resolve to Fly.
+
+### Preview app not created
+
+Check that the PR is from the same repository (not a fork). The workflow has fork protection:
+```yaml
+if: github.event.pull_request.head.repo.full_name == github.repository
+```
+
+### Images not optimized
+
+With standalone mode, Next.js uses `sharp` for image optimization. If images appear unoptimized, check that `sharp` installed correctly in the Docker build. The `node:20-alpine` base image includes the necessary native dependencies.
+
+### Blog pages return 404
+
+The Dockerfile copies `src/content/` into the runner stage because the blog system reads MDX files from disk at runtime. If blog pages 404, verify the content directory exists in the container:
+
+```bash
+fly ssh console -a afterwords-web
+ls src/content/blog/
+```

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -5,18 +5,19 @@ This guide covers the full setup, deployment, DNS configuration, and ongoing ope
 ## Architecture Overview
 
 ```
-GitHub repo (main branch)
+GitHub repo
   │
-  ├─ push to main ──→ GitHub Actions ──→ fly deploy ──→ afterwords.gr (production)
+  ├─ PR opened/updated ──→ checks (type-check + build) ──→ fly deploy ──→ afterwords-preview-pr-<N>.fly.dev
   │
-  ├─ PR opened ─────→ GitHub Actions ──→ fly deploy ──→ pr-<N>.preview.afterwords.gr
+  ├─ PR closed ───────────→ fly destroy ──→ preview app removed
   │
-  └─ PR closed ─────→ GitHub Actions ──→ fly destroy ──→ preview app removed
+  └─ push to main ────────→ checks (type-check + build) ──→ fly deploy ──→ afterwords.gr (production)
 ```
 
 - **Runtime:** Next.js standalone (SSR) in a Docker container
 - **Region:** Amsterdam (`ams`) — optimized for Greek/EU audience
 - **Scaling:** Auto-stop when idle, auto-start on request. Stopped machines cost nothing.
+- **CI checks:** Type-check (`tsc --noEmit`) and build (`next build`) must pass before any deployment.
 
 ## Initial Setup (One-Time)
 
@@ -89,7 +90,17 @@ Go to **Settings → Environments → New environment**:
 
 This ensures only pushes to `main` can trigger production deployments.
 
-## DNS Configuration (Papaki.gr)
+### 8. Enable branch protection (recommended)
+
+Go to **Settings → Branches → Add rule** for `main`:
+- Require status checks to pass: enable **"Type Check & Build"**
+- Do not allow force pushes
+
+This prevents merging PRs that fail checks.
+
+## DNS Configuration (Cloudflare)
+
+DNS for `afterwords.gr` is managed in Cloudflare.
 
 ### Step 1: Register custom domains with Fly
 
@@ -100,32 +111,25 @@ fly certs create www.afterwords.gr -a afterwords-web
 
 Fly will provision Let's Encrypt TLS certificates automatically once DNS is pointed.
 
-### Step 2: Check certificate status
+### Step 2: Configure DNS records in Cloudflare
+
+**Production (afterwords.gr):**
+
+| Type | Name | Value | Proxy |
+|------|------|-------|-------|
+| A | `@` | *(Fly IPv4 from `fly ips list`)* | DNS only (grey cloud) |
+| AAAA | `@` | *(Fly IPv6 from `fly ips list`)* | DNS only (grey cloud) |
+| CNAME | `www` | `afterwords.gr` | DNS only (grey cloud) |
+
+**Important:** Keep proxy **off** (DNS only / grey cloud). Fly needs direct access to provision and renew Let's Encrypt certificates. Cloudflare proxy would intercept TLS and break Fly's certificate validation.
+
+### Step 3: Check certificate status
 
 ```bash
 fly certs show afterwords.gr -a afterwords-web
 ```
 
 Wait until it shows `Ready`. This happens automatically once DNS propagates.
-
-### Step 3: Configure DNS records at Papaki.gr
-
-**Production (afterwords.gr):**
-
-| Type | Name | Value | TTL |
-|------|------|-------|-----|
-| A | `@` | *(Fly IPv4 from step 4 above)* | 300 |
-| AAAA | `@` | *(Fly IPv6 from step 4 above)* | 300 |
-| CNAME | `www` | `afterwords.gr` | 300 |
-
-**Preview deployments (*.preview.afterwords.gr):**
-
-| Type | Name | Value | TTL |
-|------|------|-------|-----|
-| A | `*.preview` | *(same Fly IPv4)* | 300 |
-| AAAA | `*.preview` | *(same Fly IPv6)* | 300 |
-
-The wildcard record routes all `pr-<N>.preview.afterwords.gr` traffic to Fly, which matches by hostname (SNI) to the correct preview app.
 
 ### Cutover strategy
 
@@ -134,14 +138,15 @@ The wildcard record routes all `pr-<N>.preview.afterwords.gr` traffic to Fly, wh
 3. Replace the records with the Fly IPs
 4. Verify: `curl -I https://afterwords.gr`
 5. Once confirmed, disable GitHub Pages in repo settings
+6. Remove `.github/workflows/nextjs.yml` (the old GitHub Pages workflow)
 
 ## Deploying
 
 ### Production
 
-Push or merge to `main`. That's it. The `deploy.yml` workflow:
+Push or merge to `main`. The `deploy.yml` workflow:
 
-1. Checks out the code
+1. Runs checks (type-check + build)
 2. Builds the Docker image on Fly's remote builders
 3. Deploys to the `afterwords-web` app
 
@@ -157,12 +162,31 @@ Or check the GitHub Actions tab for build logs.
 
 Open a pull request. The `preview.yml` workflow:
 
-1. Creates a Fly app named `afterwords-preview-pr-<N>` (if it doesn't exist)
-2. Provisions a TLS cert for `pr-<N>.preview.afterwords.gr`
+1. Runs checks (type-check + build)
+2. Creates a Fly app named `afterwords-preview-pr-<N>` (if it doesn't exist)
 3. Builds and deploys
 4. Comments on the PR with the preview URL
 
+Preview URLs use Fly's default domain: `https://afterwords-preview-pr-<N>.fly.dev`
+
+TLS is automatic on `.fly.dev` — no DNS or certificate setup needed.
+
 When the PR is closed or merged, the preview app is automatically destroyed.
+
+**Fork safety:** The workflow only runs for PRs from the same repository, not from forks.
+
+## CI Checks
+
+Both the preview and production workflows run these checks before deploying:
+
+| Check | Command | What it catches |
+|-------|---------|-----------------|
+| Type check | `tsc --noEmit` | Type errors |
+| Build | `next build` | Build failures, missing imports, SSR errors |
+
+If either check fails, the deployment is skipped.
+
+**Note:** Lint (`next lint`) is currently disabled due to a Next.js 16 compatibility issue and pre-existing lint errors. It can be re-enabled after fixing those errors.
 
 ## Operations
 
@@ -273,8 +297,8 @@ All `NEXT_PUBLIC_*` variables are inlined at build time by Next.js. They are pas
 | `Dockerfile` | Multi-stage Docker build for Next.js standalone |
 | `.dockerignore` | Files excluded from Docker build context |
 | `.env.example` | Documents required environment variables |
-| `.github/workflows/deploy.yml` | Production deployment workflow |
-| `.github/workflows/preview.yml` | PR preview deployment workflow |
+| `.github/workflows/deploy.yml` | Production deployment workflow (checks + deploy) |
+| `.github/workflows/preview.yml` | PR preview deployment workflow (checks + deploy + destroy) |
 
 ## Costs (Fly.io)
 
@@ -284,15 +308,22 @@ With `auto_stop_machines = "stop"` and `min_machines_running = 0`:
 - **Active (shared-cpu-1x, 256MB):** ~$1.94/month if running 24/7
 - **Bandwidth:** 100GB/month free outbound, then $0.02/GB
 - **Remote builder:** free tier covers small projects
+- **Preview apps:** $0 when idle (auto-stopped), destroyed on PR close
 
 For a low-traffic site, expect **$3–5/month** total.
 
 ## Troubleshooting
 
+### CI checks fail
+
+Check the GitHub Actions tab for the specific error:
+- **Type check fails:** Fix TypeScript errors shown in the log
+- **Build fails:** Check for missing imports, SSR-incompatible code, or environment variable issues
+
 ### Build fails in GitHub Actions
 
-Check the Actions tab for logs. Common issues:
-- Missing `FLY_API_TOKEN` secret
+Common issues:
+- Missing `FLY_API_TOKEN` secret → "no access token available"
 - npm dependency issues (try `npm ci` locally first)
 - Docker build errors (test locally with `docker build .`)
 
@@ -311,7 +342,7 @@ fly status -a afterwords-web
 fly certs show afterwords.gr -a afterwords-web
 ```
 
-Ensure DNS records point to Fly IPs. Certificate provisioning requires DNS to be correctly configured. It uses HTTP-01 validation, so the domain must resolve to Fly.
+Ensure DNS records point to Fly IPs with **proxy off** (DNS only) in Cloudflare. Certificate provisioning requires direct access — Cloudflare proxy intercepts TLS and breaks Fly's HTTP-01 validation.
 
 ### Preview app not created
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,26 @@
+app = "afterwords-web"
+primary_region = "ams"
+
+[build]
+
+[env]
+  PORT = "3000"
+  NODE_ENV = "production"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 250
+    soft_limit = 200
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
-  output: "export",
-  images: { unoptimized: true },
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/src/app/blog/feed.xml/route.ts
+++ b/src/app/blog/feed.xml/route.ts
@@ -2,7 +2,7 @@ import { getAllPosts } from "~/lib/blog";
 
 export const dynamic = "force-static";
 
-const SITE_URL = "https://afterwords.github.io";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://afterwords.gr";
 
 export async function GET() {
   const posts = await getAllPosts();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,25 +26,33 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={noto.className}>{children}</body>
-      <Script
-        async
-        src="https://www.googletagmanager.com/gtag/js?id=G-5NHQFR2NKS"
-        strategy="afterInteractive"
-      />
-      <Script id="gtag-init" strategy="afterInteractive">{`
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-5NHQFR2NKS');
-      `}</Script>
-      <Script
-        id="beacon-1"
-        type="text/javascript"
-      >{`!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});`}</Script>
-      <Script
-        id="beacon-2"
-        type="text/javascript"
-      >{`window.Beacon('init', '59d3cf5c-2a28-4cd5-a299-7cc71501140d')`}</Script>
+      {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
+        <>
+          <Script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}`}
+            strategy="afterInteractive"
+          />
+          <Script id="gtag-init" strategy="afterInteractive">{`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}');
+          `}</Script>
+        </>
+      )}
+      {process.env.NEXT_PUBLIC_HELPSCOUT_BEACON_ID && (
+        <>
+          <Script
+            id="beacon-1"
+            type="text/javascript"
+          >{`!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});`}</Script>
+          <Script
+            id="beacon-2"
+            type="text/javascript"
+          >{`window.Beacon('init', '${process.env.NEXT_PUBLIC_HELPSCOUT_BEACON_ID}')`}</Script>
+        </>
+      )}
     </html>
   );
 }


### PR DESCRIPTION
## Summary

- Switch Next.js from static export (`output: "export"`) to standalone SSR (`output: "standalone"`)
- Add multi-stage Dockerfile and `fly.toml` targeting Amsterdam region for EU/Greek audience
- Add GitHub Actions workflows for production deploys (push to main) and per-PR preview environments (`pr-<N>.preview.afterwords.gr`)
- Extract hardcoded Google Analytics, HelpScout, and site URL values to `NEXT_PUBLIC_*` environment variables
- Add deployment guide in `docs/deployment-guide.md` covering setup, DNS, operations, and troubleshooting

## Before merging

Complete the one-time setup steps documented in `docs/deployment-guide.md`:

1. Install Fly CLI and create the `afterwords-web` app
2. Allocate IPs and set Fly secrets
3. Add `FLY_API_TOKEN`, `GA_MEASUREMENT_ID`, `HELPSCOUT_BEACON_ID` as GitHub Actions secrets
4. Add `SITE_URL` as a GitHub Actions variable
5. Create the `production` environment in GitHub (restricted to `main`)
6. Configure DNS at Papaki.gr (can be done after first successful deploy to verify on `.fly.dev`)

## Test plan

- [ ] Verify `npm run build` succeeds locally with standalone output
- [ ] Create Fly app and deploy manually once to verify Docker build works
- [ ] Confirm site loads at `afterwords-web.fly.dev` (all pages, blog, RSS feed)
- [ ] Open a test PR to verify preview deployment workflow
- [ ] Configure DNS and verify TLS certificate provisioning
- [ ] Disable GitHub Pages after production cutover is confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)