### PR TITLE
Design iteration 2: Refinements & polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/mdx": "^2.0.13",
         "a11y-react-emoji": "^1.2.0",
         "daisyui": "^5.5.19",
+        "framer-motion": "^12.38.0",
         "next": "16.1.6",
         "next-mdx-remote": "^6.0.0",
         "react": "^19.0.0",
@@ -3681,6 +3682,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5917,6 +5945,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/mdx": "^2.0.13",
     "a11y-react-emoji": "^1.2.0",
     "daisyui": "^5.5.19",
+    "framer-motion": "^12.38.0",
     "next": "16.1.6",
     "next-mdx-remote": "^6.0.0",
     "react": "^19.0.0",

--- a/src/app/academic-translation/page.tsx
+++ b/src/app/academic-translation/page.tsx
@@ -2,9 +2,16 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { ServiceCard } from "~/components/Services";
-import LabeledEmoji from "~/components/LabeledEmoji";
-import { Header } from "~/components/Header";
+import { motion } from "framer-motion";
+import { PageHero } from "~/components/PageHero";
+import { SectionHeader } from "~/components/SectionHeader";
+import { CTASection } from "~/components/CTASection";
+import { Footer } from "~/components/Footer";
+import { FadeIn } from "~/components/animations/FadeIn";
+import {
+  StaggerContainer,
+  StaggerItem,
+} from "~/components/animations/StaggerContainer";
 
 declare global {
   interface Window {
@@ -17,54 +24,75 @@ const services = [
   {
     id: 1,
     label: "Academic Books & Textbooks",
-    description: (
-      <>
-        <p className="mb-4">
-          Specializing in STEM, Econometrics, and Social Sciences with Subject Matter Experts (SMEs) paired with advanced Translation Memories for guaranteed terminology consistency.
-        </p>
-      </>
-    )
+    color: "from-amber-900 to-amber-800",
+    spine: "bg-amber-950",
+    description:
+      "Specializing in STEM, Econometrics, and Social Sciences with Subject Matter Experts (SMEs) paired with advanced Translation Memories for guaranteed terminology consistency.",
   },
   {
     id: 2,
     label: "Literature & Creative Non-Fiction",
-    description: (
-      <>
-        <p className="mb-4">
-          Sensitive translation for Memoirs and Novels that preserves authorial &ldquo;voice&rdquo; and charisma—something AI cannot replicate.
-        </p>
-      </>
-    )
+    color: "from-emerald-900 to-emerald-800",
+    spine: "bg-emerald-950",
+    description:
+      "Sensitive translation for Memoirs and Novels that preserves authorial \u201cvoice\u201d and charisma\u2014something AI cannot replicate.",
   },
   {
     id: 3,
     label: "E-learning & Digital Education",
-    description: (
-      <>
-        <p className="mb-4">
-          Localizing interactive course materials and pedagogical platforms for global learning environments.
-        </p>
-      </>
-    )
+    color: "from-sky-900 to-sky-800",
+    spine: "bg-sky-950",
+    description:
+      "Localizing interactive course materials and pedagogical platforms for global learning environments.",
   },
   {
     id: 4,
     label: "Journal Manuscripts",
-    description: (
-      <>
-        <p className="mb-4">
-          Ensuring research is &ldquo;journal-ready&rdquo; for international peer-reviewed publication with precise academic language.
-        </p>
-      </>
-    )
-  }
+    color: "from-rose-900 to-rose-800",
+    spine: "bg-rose-950",
+    description:
+      "Ensuring research is \u201cjournal-ready\u201d for international peer-reviewed publication with precise academic language.",
+  },
+];
+
+const whyUsItems = [
+  {
+    title: "Fixed Budget Models",
+    description:
+      "Fixed royalty or budget models eliminate financial uncertainty and integrate seamlessly with your production cycle.",
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  {
+    title: "Strict Deadline Compliance",
+    description:
+      "We consistently meet strict print deadlines without compromising literary quality by combining CAT tools with expert linguists.",
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  {
+    title: "International Standards",
+    description:
+      "We deliver manuscripts that meet the highest international standards for academic publishing.",
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+      </svg>
+    ),
+  },
 ];
 
 const specializations = [
-  { emoji: "📊", label: "Econometrics" },
-  { emoji: "💼", label: "Economics" },
-  { emoji: "🏛️", label: "Politics" },
-  { emoji: "🎓", label: "Pedagogics" }
+  { emoji: "\uD83D\uDCCA", label: "Econometrics" },
+  { emoji: "\uD83D\uDCBC", label: "Economics" },
+  { emoji: "\uD83C\uDFDB\uFE0F", label: "Politics" },
+  { emoji: "\uD83C\uDF93", label: "Pedagogics" },
 ];
 
 export default function AcademicTranslationPage() {
@@ -76,227 +104,229 @@ export default function AcademicTranslationPage() {
 
   return (
     <div className="w-full bg-base-100 text-base-content">
-      {/* Hero Section */}
-      <div className="hero-section bg-sl h-full pb-16">
-        <div>
-          <section className="relative w-full overflow-hidden bg-slate-900">
-            <div className="container mx-auto px-4 md:px-8"></div>
-            <Image
-              src="/bg-academic.jpg"
-              alt="Professional signing document"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-r from-slate-900 via-slate-900/90 to-transparent"></div>
-            <div className="relative z-10 h-full items-center px-8 lg:px-24">
-              <Header navItems={navItems} />
-              <div className="max-w-xl text-white mt-8">
-                <div>
-                  <h4 className="bg-accent text-accent-content text-xs shadow-lg rounded-3xl inline-block mb-8 px-4 py-2">
-                    A boutique Greek agency specializing in long-form academic translation
-                  </h4>
-                  <h1 className="text-5xl leading-tight font-bold mb-4">
-                    High-Stakes Academic Translation: Beyond the Algorithm
-                  </h1>
-                  <p className="text-xl mb-16">
-                    In scholarly publishing, a &ldquo;near-miss&rdquo; costs more than just credibility—it costs your budget. Unlike AI, our human-led process preserves the author&apos;s unique voice and charisma.
-                  </p>
-                  <div className="flex flex-col sm:flex-row gap-4">
-                    <button
-                      className="btn btn-lg btn-accent"
-                      onClick={() => window.Beacon("open")}
-                    >
-                      Get a free estimate
-                    </button>
-                    <Link
-                      href="/portfolio"
-                      className="btn btn-lg btn-outline btn-accent"
-                    >
-                      View Portfolio
-                    </Link>
-                  </div>
-                </div>
-              </div>
-              <div className="grid grid-cols-1 gap-8 md:grid-cols-3 my-16 text-white">
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Subject Matter Experts</h4>
-                  <p>Pairing linguists with advanced Translation Memories guarantees absolute terminology consistency across every chapter.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">TEP Workflow</h4>
-                  <p>Gold-standard Translation, Editing, Proofreading workflow eliminates costly reprints and brand damage.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Professional Stamina</h4>
-                  <p>Maintaining technical accuracy from preface to index for 500+ page academic manuscripts.</p>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
-
-      {/* About Section */}
-      <div className="container mx-auto">
-        <div className="lg:w-2/3 p-8">
-          <p className="text-2xl mb-2 text-muted-foreground">
-            Athens-based boutique agency
-          </p>
-          <h2 className="text-4xl font-bold mb-8">
-            Precision and Stamina for <i className="font-normal">Long-Form</i> Projects
-          </h2>
-          <p className="text-xl mb-4">
-            We specialize in long-form academic translation for textbooks in Econometrics, Economics, Politics, and Pedagogics.
-            Whether managing dense Econometrics data or complex Pedagogical theory, we deliver manuscripts that meet the highest international standards.
-          </p>
-          <p className="text-xl mb-8">
-            We eliminate the risks of a &ldquo;Bad Translation&rdquo;—such as costly reprints and brand damage—by utilizing a gold-standard TEP (Translation, Editing, Proofreading) workflow.
-          </p>
-        </div>
-      </div>
-
-      {/* Services Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8" id="services">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our specialized academic services
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Service Portfolio</h2>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 mb-8">
-              {services.map((service) => (
-                <ServiceCard
-                  key={service.id}
-                  label={service.label}
-                  description={service.description}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Why Us Section */}
-      <div className="bg-base-300">
-        <div className="container mx-auto">
-          <div className="p-8" id="why">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Why choose us
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Beyond AI Limitations</h2>
-            <p className="text-xl mb-8 md:w-3/4 lg:w-2/3">
-              Unlike AI, which often misses nuance and metaphor, our human-led process preserves the author&apos;s unique voice and charisma.
-            </p>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 mb-8">
-              <ServiceCard
-                label="Fixed Budget Models"
-                description="Fixed royalty or budget models eliminate financial uncertainty and integrate seamlessly with your production cycle."
-              />
-              <ServiceCard
-                label="Strict Deadline Compliance"
-                description="We consistently meet strict print deadlines without compromising literary quality by combining CAT tools with expert linguists."
-              />
-              <ServiceCard
-                label="International Standards"
-                description="We deliver manuscripts that meet the highest international standards for academic publishing."
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Specializations Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our expertise
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Deep Specialization</h2>
-            <p className="text-xl mb-8 lg:w-2/3">
-              We provide end-to-end linguistic solutions for high-volume and high-impact publishing projects.
-            </p>
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-              {specializations.map((spec) => (
-                <LabeledEmoji key={spec.label} emoji={spec.emoji} label={spec.label} />
-              ))}
-            </div>
-            <Image
-              alt="I work with SDL Trados Studio"
-              width={200}
-              height={50}
-              src="/trados.png"
-              className="sm:w-2/3 lg:w-2/5"
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* CTA Section */}
-      <div className="hero-section h-full pb-16 text-white" style={{ background: 'linear-gradient(to top right, oklch(27% 0.041 260.031), oklch(44% 0.043 257.281), oklch(27% 0.046 192.524))' }}>
-        <div className="container mx-auto">
-          <div className="xl:w-2/3 p-8 pb-0 text-white">
-            <p className="text-2xl text-slate-400 mb-2">
-              Ready to discuss your academic translation project?
-            </p>
-            <h3 className="text-4xl font-bold mb-8">
-              Let&apos;s talk about your book
-            </h3>
-            <p className="text-xl mb-8 md:w-2/3">
-              Whether it&apos;s a 500-page textbook or a journal manuscript, we have the expertise and professional stamina to deliver excellence.
-            </p>
+      {/* ── Hero ── */}
+      <PageHero
+        navItems={navItems}
+        badge="A boutique Greek agency specializing in long-form academic translation"
+        title="High-Stakes Academic Translation: Beyond the Algorithm"
+        subtitle="In scholarly publishing, a &ldquo;near-miss&rdquo; costs more than just credibility&mdash;it costs your budget. Unlike AI, our human-led process preserves the author&apos;s unique voice and charisma."
+        variant="full"
+        cta={
+          <div className="flex flex-col sm:flex-row gap-4">
             <button
-              className="btn btn-accent"
+              className="group relative inline-flex items-center gap-2 bg-warm text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-warm-dark hover:text-white transition-all duration-300 hover:shadow-lg hover:shadow-warm/20"
               onClick={() => window.Beacon("open")}
             >
-              Contact us →
+              Get a free estimate
+              <svg
+                className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+              </svg>
             </button>
+            <Link
+              href="/portfolio"
+              className="inline-flex items-center gap-2 border border-white/30 text-white font-semibold px-8 py-4 rounded-xl hover:bg-white/10 transition-all duration-300"
+            >
+              View Portfolio
+            </Link>
           </div>
-        </div>
-      </div>
+        }
+        features={[
+          {
+            title: "Subject Matter Experts",
+            description:
+              "Pairing linguists with advanced Translation Memories guarantees absolute terminology consistency across every chapter.",
+          },
+          {
+            title: "TEP Workflow",
+            description:
+              "Gold-standard Translation, Editing, Proofreading workflow eliminates costly reprints and brand damage.",
+          },
+          {
+            title: "Professional Stamina",
+            description:
+              "Maintaining technical accuracy from preface to index for 500+ page academic manuscripts.",
+          },
+        ]}
+        backgroundElement={
+          <>
+            {/* Warm parchment-toned gradient — scholarly feel */}
+            <div className="absolute inset-0 bg-gradient-to-br from-[#2c1e10] via-[#3b2a18] to-slate-900" />
+            {/* Subtle book-spine vertical lines */}
+            <div className="absolute inset-0 opacity-[0.04]"
+              style={{
+                backgroundImage:
+                  "repeating-linear-gradient(90deg, transparent, transparent 60px, rgba(255,220,180,0.3) 60px, rgba(255,220,180,0.3) 62px)",
+              }}
+            />
+            {/* Warm glow */}
+            <div className="absolute top-1/4 -left-32 w-[600px] h-[600px] rounded-full bg-amber-800/20 blur-[150px]" />
+            <div className="absolute bottom-0 right-0 w-96 h-96 rounded-full bg-warm/10 blur-[120px]" />
+          </>
+        }
+      />
 
-      {/* Footer */}
-      <div className="bg-slate-900">
-        <div className="container mx-auto p-8">
-          <Image
-            alt="Afterwords logo"
-            src="/logo.svg"
-            width={200}
-            height={50}
-            className="mb-8 w-1/3 md:w-1/4"
-          />
-          <div className="flex items-center">
-            <h3 className="text-white text-xl mr-4">Find us on social media</h3>
-            <a href="https://www.instagram.com/afterwordstranslations/" className="inline-block mr-4">
-              <Image
-                alt="Instagram logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/insta.svg"
-              />
-            </a>
-            <a href="https://www.linkedin.com/company/afterwordstranslations" className="inline-block mr-4">
-              <Image
-                alt="LinkedIn logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/in.png"
-              />
-            </a>
-            <a href="https://www.facebook.com/AfterWordstranslations" className="inline-block mr-4">
-              <Image
-                alt="Facebook logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/fb.png"
-              />
-            </a>
+      {/* ── About Section ── */}
+      <section className="py-20 md:py-28">
+        <div className="container mx-auto px-8">
+          <div className="max-w-3xl">
+            <SectionHeader
+              eyebrow="Athens-based boutique agency"
+              title="Precision and Stamina for"
+              titleItalic="Long-Form Projects"
+            />
+            <FadeIn delay={0.2}>
+              <p className="text-lg md:text-xl leading-relaxed text-base-content/70 mt-8">
+                We specialize in long-form academic translation for textbooks in Econometrics, Economics, Politics, and Pedagogics. Whether managing dense Econometrics data or complex Pedagogical theory, we deliver manuscripts that meet the highest international standards.
+              </p>
+            </FadeIn>
+            <FadeIn delay={0.3}>
+              <p className="text-lg md:text-xl leading-relaxed text-base-content/70 mt-4">
+                We eliminate the risks of a &ldquo;Bad Translation&rdquo;&mdash;such as costly reprints and brand damage&mdash;by utilizing a gold-standard TEP (Translation, Editing, Proofreading) workflow.
+              </p>
+            </FadeIn>
           </div>
         </div>
-      </div>
+      </section>
+
+      {/* ── Services — Bookshelf Layout ── */}
+      <section className="py-20 md:py-28 bg-gradient-to-b from-amber-50/50 to-base-100" id="services">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our specialized academic services"
+            title="Service Portfolio"
+          />
+
+          <StaggerContainer
+            className="grid gap-8 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 mt-16"
+            staggerDelay={0.12}
+          >
+            {services.map((service) => (
+              <StaggerItem key={service.id}>
+                <motion.div
+                  className="group relative cursor-default"
+                  style={{ perspective: "800px" }}
+                  whileHover="hover"
+                >
+                  <motion.div
+                    className={`relative rounded-lg bg-gradient-to-b ${service.color} p-6 pt-10 pb-8 shadow-lg min-h-[280px] flex flex-col`}
+                    variants={{
+                      hover: {
+                        rotateY: -6,
+                        scale: 1.03,
+                        boxShadow: "8px 8px 24px rgba(0,0,0,0.25)",
+                        transition: { duration: 0.35, ease: "easeOut" },
+                      },
+                    }}
+                    style={{ transformStyle: "preserve-3d" }}
+                  >
+                    {/* Spine accent */}
+                    <div
+                      className={`absolute left-0 top-0 bottom-0 w-2 rounded-l-lg ${service.spine}`}
+                    />
+                    {/* Faux page edges */}
+                    <div className="absolute right-0 top-2 bottom-2 w-1 bg-white/10 rounded-r" />
+                    <div className="absolute right-1 top-3 bottom-3 w-[2px] bg-white/5 rounded-r" />
+
+                    <h3 className="font-[family-name:var(--font-display)] text-xl font-bold text-white mb-4 leading-snug">
+                      {service.label}
+                    </h3>
+                    <p className="text-white/70 text-sm leading-relaxed mt-auto">
+                      {service.description}
+                    </p>
+                  </motion.div>
+                </motion.div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* ── Why Us ── */}
+      <section className="py-20 md:py-28 bg-base-200/50" id="why">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Why choose us"
+            title="Beyond AI Limitations"
+            description="Unlike AI, which often misses nuance and metaphor, our human-led process preserves the author&apos;s unique voice and charisma."
+          />
+
+          <StaggerContainer
+            className="grid gap-8 grid-cols-1 md:grid-cols-3 mt-16"
+            staggerDelay={0.15}
+          >
+            {whyUsItems.map((item) => (
+              <StaggerItem key={item.title}>
+                <div className="bg-base-100 rounded-2xl p-8 shadow-sm hover:shadow-md transition-shadow duration-300 border border-base-content/5 h-full">
+                  <div className="w-12 h-12 rounded-xl bg-warm/15 text-warm flex items-center justify-center mb-6">
+                    {item.icon}
+                  </div>
+                  <h3 className="font-[family-name:var(--font-display)] text-xl font-bold mb-3 text-base-content">
+                    {item.title}
+                  </h3>
+                  <p className="text-base-content/60 leading-relaxed">
+                    {item.description}
+                  </p>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* ── Specializations — Discipline Tags ── */}
+      <section className="py-20 md:py-28">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our expertise"
+            title="Deep Specialization"
+            description="We provide end-to-end linguistic solutions for high-volume and high-impact publishing projects."
+          />
+
+          <StaggerContainer
+            className="flex flex-wrap gap-4 mt-12"
+            staggerDelay={0.1}
+          >
+            {specializations.map((spec) => (
+              <StaggerItem key={spec.label}>
+                <span className="inline-flex items-center gap-3 bg-gradient-to-r from-amber-50 to-warm-subtle border border-warm/20 rounded-full px-6 py-3 text-base font-semibold text-base-content shadow-sm hover:shadow-md hover:border-warm/40 transition-all duration-300">
+                  <span className="text-xl">{spec.emoji}</span>
+                  {spec.label}
+                </span>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+
+          {/* Trados logo — subtle treatment */}
+          <FadeIn delay={0.3} className="mt-16">
+            <div className="flex items-center gap-4 opacity-60 hover:opacity-100 transition-opacity duration-500">
+              <div className="h-px w-12 bg-base-content/20" />
+              <Image
+                alt="I work with SDL Trados Studio"
+                width={200}
+                height={50}
+                src="/trados.png"
+                className="w-40 grayscale hover:grayscale-0 transition-all duration-500"
+              />
+            </div>
+          </FadeIn>
+        </div>
+      </section>
+
+      {/* ── CTA ── */}
+      <CTASection
+        eyebrow="Ready to discuss your academic translation project?"
+        title="Let&apos;s talk about your book"
+        description="Whether it&apos;s a 500-page textbook or a journal manuscript, we have the expertise and professional stamina to deliver excellence."
+        buttonText="Contact us"
+      />
+
+      {/* ── Footer ── */}
+      <Footer />
     </div>
   );
 }

--- a/src/app/academic-translation/page.tsx
+++ b/src/app/academic-translation/page.tsx
@@ -89,10 +89,38 @@ const whyUsItems = [
 ];
 
 const specializations = [
-  { emoji: "\uD83D\uDCCA", label: "Econometrics" },
-  { emoji: "\uD83D\uDCBC", label: "Economics" },
-  { emoji: "\uD83C\uDFDB\uFE0F", label: "Politics" },
-  { emoji: "\uD83C\uDF93", label: "Pedagogics" },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+      </svg>
+    ),
+    label: "Econometrics",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
+      </svg>
+    ),
+    label: "Economics",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0012 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75z" />
+      </svg>
+    ),
+    label: "Politics",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342M6.75 15a.75.75 0 100-1.5.75.75 0 000 1.5zm0 0v-3.675A55.378 55.378 0 0112 8.443m-7.007 11.55A5.981 5.981 0 006.75 15.75v-1.5" />
+      </svg>
+    ),
+    label: "Pedagogics",
+  },
 ];
 
 export default function AcademicTranslationPage() {
@@ -294,7 +322,7 @@ export default function AcademicTranslationPage() {
             {specializations.map((spec) => (
               <StaggerItem key={spec.label}>
                 <span className="inline-flex items-center gap-3 bg-gradient-to-r from-amber-50 to-warm-subtle border border-warm/20 rounded-full px-6 py-3 text-base font-semibold text-base-content shadow-sm hover:shadow-md hover:border-warm/40 transition-all duration-300">
-                  <span className="text-xl">{spec.emoji}</span>
+                  <span className="text-warm-dark">{spec.icon}</span>
                   {spec.label}
                 </span>
               </StaggerItem>

--- a/src/app/audiovisual-translation/page.tsx
+++ b/src/app/audiovisual-translation/page.tsx
@@ -65,10 +65,38 @@ const whyUs = [
 ];
 
 const specializations = [
-  { emoji: "\uD83C\uDFAC", label: "Film Festivals" },
-  { emoji: "\uD83C\uDFAD", label: "Theatre" },
-  { emoji: "\uD83D\uDCFA", label: "TV Series" },
-  { emoji: "\uD83C\uDFA5", label: "Documentaries" },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h1.5C5.496 19.5 6 18.996 6 18.375m-3.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-1.5A1.125 1.125 0 0118 18.375M20.625 4.5H3.375m17.25 0c.621 0 1.125.504 1.125 1.125M20.625 4.5h-1.5C18.504 4.5 18 5.004 18 5.625m3.75 0v1.5c0 .621-.504 1.125-1.125 1.125M3.375 4.5c-.621 0-1.125.504-1.125 1.125M3.375 4.5h1.5C5.496 4.5 6 5.004 6 5.625m-3.75 0v1.5c0 .621.504 1.125 1.125 1.125m0 0h1.5m-1.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m1.5-3.75C5.496 8.25 6 7.746 6 7.125v-1.5M4.875 8.25C5.496 8.25 6 8.754 6 9.375v1.5m0-5.25v5.25m0-5.25C6 5.004 6.504 4.5 7.125 4.5h9.75c.621 0 1.125.504 1.125 1.125m1.125 2.625h1.5m-1.5 0A1.125 1.125 0 0118 7.125v-1.5m1.125 2.625c-.621 0-1.125.504-1.125 1.125v1.5m2.625-2.625c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125M18 5.625v5.25M7.125 12h9.75m-9.75 0A1.125 1.125 0 016 10.875M7.125 12C6.504 12 6 12.504 6 13.125m0-2.25C6 11.496 5.496 12 4.875 12M18 10.875c0 .621-.504 1.125-1.125 1.125M18 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m-12 5.25v-5.25m0 5.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125m-12 0v-1.5c0-.621-.504-1.125-1.125-1.125M18 18.375v-5.25m0 5.25v-1.5c0-.621.504-1.125 1.125-1.125M18 13.125v1.5c0 .621.504 1.125 1.125 1.125M18 13.125c0-.621.504-1.125 1.125-1.125M6 13.125v1.5c0 .621-.504 1.125-1.125 1.125M6 13.125C6 12.504 5.496 12 4.875 12m-1.5 0h1.5m-1.5 0c-.621 0-1.125-.504-1.125-1.125v-1.5c0-.621.504-1.125 1.125-1.125m1.5 0c-.621 0-1.125-.504-1.125-1.125v-1.5c0-.621.504-1.125 1.125-1.125" />
+      </svg>
+    ),
+    label: "Film Festivals",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15.182 15.182a4.5 4.5 0 01-6.364 0M21 12a9 9 0 11-18 0 9 9 0 0118 0zM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75zm-.375 0h.008v.015h-.008V9.75zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75zm-.375 0h.008v.015h-.008V9.75z" />
+      </svg>
+    ),
+    label: "Theatre",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 20.25h12m-7.5-3v3m3-3v3m-10.125-3h17.25c.621 0 1.125-.504 1.125-1.125V4.875c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125z" />
+      </svg>
+    ),
+    label: "TV Series",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" d="M15.75 10.5l4.72-4.72a.75.75 0 011.28.53v11.38a.75.75 0 01-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 002.25 7.5v9a2.25 2.25 0 002.25 2.25z" />
+      </svg>
+    ),
+    label: "Documentaries",
+  },
 ];
 
 const navItems = [
@@ -290,7 +318,7 @@ export default function AudiovisualTranslationPage() {
                 >
                   {/* Dramatic top glow on hover */}
                   <div className="absolute inset-x-0 top-0 h-[1px] bg-gradient-to-r from-transparent via-amber-400/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-                  <span className="text-3xl mr-3">{spec.emoji}</span>
+                  <span className="text-warm mr-3">{spec.icon}</span>
                   <span className="text-lg font-semibold text-white tracking-wide uppercase">
                     {spec.label}
                   </span>

--- a/src/app/audiovisual-translation/page.tsx
+++ b/src/app/audiovisual-translation/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
-import { ServiceCard } from "~/components/Services";
-import LabeledEmoji from "~/components/LabeledEmoji";
-import { Header } from "~/components/Header";
+import { motion } from "framer-motion";
+import { PageHero } from "~/components/PageHero";
+import { SectionHeader } from "~/components/SectionHeader";
+import { CTASection } from "~/components/CTASection";
+import { Footer } from "~/components/Footer";
+import { FadeIn } from "~/components/animations/FadeIn";
+import {
+  StaggerContainer,
+  StaggerItem,
+} from "~/components/animations/StaggerContainer";
 
 declare global {
   interface Window {
@@ -17,278 +23,294 @@ const services = [
   {
     id: 1,
     label: "TV Series & Episodic Content",
-    description: (
-      <>
-        <p className="mb-4">
-          Comprehensive subtitling for television series with consistent character voice and terminology throughout entire seasons.
-        </p>
-      </>
-    )
+    description:
+      "Comprehensive subtitling for television series with consistent character voice and terminology throughout entire seasons.",
   },
   {
     id: 2,
     label: "Documentaries & Non-Fiction",
-    description: (
-      <>
-        <p className="mb-4">
-          Precise translation that preserves the educational and informational integrity of documentary content across all genres.
-        </p>
-      </>
-    )
+    description:
+      "Precise translation that preserves the educational and informational integrity of documentary content across all genres.",
   },
   {
     id: 3,
     label: "Feature Films & Cinema",
-    description: (
-      <>
-        <p className="mb-4">
-          Theatre-quality subtitles that capture the emotional nuance and dramatic timing of feature film productions.
-        </p>
-      </>
-    )
+    description:
+      "Theatre-quality subtitles that capture the emotional nuance and dramatic timing of feature film productions.",
   },
   {
     id: 4,
     label: "Theatre & Live Performance",
-    description: (
-      <>
-        <p className="mb-4">
-          Specialized subtitling for theatre performances and live events, respecting the unique dynamics of staged productions.
-        </p>
-      </>
-    )
-  }
+    description:
+      "Specialized subtitling for theatre performances and live events, respecting the unique dynamics of staged productions.",
+  },
+];
+
+const whyUs = [
+  {
+    label: "Tone Adaptation",
+    description:
+      "We navigate all genres and registers with ease, ensuring that the tone of your original content\u2014whether comedic, technical, or dramatic\u2014is perfectly adapted for your target viewers.",
+  },
+  {
+    label: "Industry Turnaround",
+    description:
+      "We understand the tight turnaround times inherent in the entertainment industry and deliver high-quality subtitles without ever sacrificing accuracy.",
+  },
+  {
+    label: "Professional Workflow",
+    description:
+      "Partner with us for a seamless, professional viewing experience that respects both the art on screen and the constraints of your deadline.",
+  },
 ];
 
 const specializations = [
-  { emoji: "🎬", label: "Film Festivals" },
-  { emoji: "🎭", label: "Theatre" },
-  { emoji: "📺", label: "TV Series" },
-  { emoji: "🎥", label: "Documentaries" }
+  { emoji: "\uD83C\uDFAC", label: "Film Festivals" },
+  { emoji: "\uD83C\uDFAD", label: "Theatre" },
+  { emoji: "\uD83D\uDCFA", label: "TV Series" },
+  { emoji: "\uD83C\uDFA5", label: "Documentaries" },
 ];
 
-export default function AudiovisualTranslationPage() {
-  const navItems = [
-    { label: "Home", href: "/" },
-    { label: "Our services", href: "#services" },
-    { label: "Why us", href: "#why" },
-  ];
+const navItems = [
+  { label: "Home", href: "/" },
+  { label: "Our services", href: "#services" },
+  { label: "Why us", href: "#why" },
+];
 
+const heroFeatures = [
+  {
+    title: "Flawless Synchronization",
+    description:
+      "Industry-leading software guarantees precise timing and formatting for seamless viewer experiences.",
+  },
+  {
+    title: "Genre Versatility",
+    description:
+      "We navigate all genres and registers\u2014comedic, technical, or dramatic\u2014with equal expertise.",
+  },
+  {
+    title: "Reliable Speed",
+    description:
+      "Understanding tight entertainment industry turnaround times without sacrificing accuracy.",
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  Film-grain CSS overlay via inline keyframes                        */
+/* ------------------------------------------------------------------ */
+const filmGrainStyle = `
+@keyframes grain {
+  0%, 100% { transform: translate(0, 0); }
+  10% { transform: translate(-5%, -10%); }
+  20% { transform: translate(-15%, 5%); }
+  30% { transform: translate(7%, -25%); }
+  40% { transform: translate(-5%, 25%); }
+  50% { transform: translate(-15%, 10%); }
+  60% { transform: translate(15%, 0%); }
+  70% { transform: translate(0%, 15%); }
+  80% { transform: translate(3%, 35%); }
+  90% { transform: translate(-10%, 10%); }
+}
+`;
+
+export default function AudiovisualTranslationPage() {
   return (
     <div className="w-full bg-base-100 text-base-content">
-      {/* Hero Section */}
-      <div className="hero-section bg-sl h-full pb-16">
-        <div>
-          <section className="relative w-full overflow-hidden bg-slate-900">
-            <div className="container mx-auto px-4 md:px-8"></div>
-            <Image
-              src="/bg-cinema.jpg"
-              alt="Cinema screen with subtitles"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-r from-slate-900 via-slate-900/90 to-transparent"></div>
-            <div className="relative z-10 h-full items-center px-8 lg:px-24">
-              <Header navItems={navItems} />
-              <div className="max-w-xl text-white mt-8">
-                <div>
-                  <h4 className="bg-accent text-accent-content text-xs shadow-lg rounded-3xl inline-block mb-8 px-4 py-2">
-                    Bridging borders through expert audiovisual translation
-                  </h4>
-                  <h1 className="text-5xl leading-tight font-bold mb-4">
-                    Bringing Your Content to Global Audiences
-                  </h1>
-                  <p className="text-xl mb-16">
-                    From TV series to feature films and entire film festivals, we ensure the narrative remains sharp and impactful across every frame.
-                  </p>
-                  <div className="flex flex-col sm:flex-row gap-4">
-                    <button
-                      className="btn btn-lg btn-accent"
-                      onClick={() => window.Beacon("open")}
-                    >
-                      Get a free estimate
-                    </button>
-                    <Link
-                      href="/portfolio"
-                      className="btn btn-lg btn-outline btn-accent"
-                    >
-                      View Portfolio
-                    </Link>
-                  </div>
-                </div>
-              </div>
-              <div className="grid grid-cols-1 gap-8 md:grid-cols-3 my-16 text-white">
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Flawless Synchronization</h4>
-                  <p>Industry-leading software guarantees precise timing and formatting for seamless viewer experiences.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Genre Versatility</h4>
-                  <p>We navigate all genres and registers—comedic, technical, or dramatic—with equal expertise.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Reliable Speed</h4>
-                  <p>Understanding tight entertainment industry turnaround times without sacrificing accuracy.</p>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
+      {/* Inject film-grain keyframe */}
+      <style>{filmGrainStyle}</style>
 
-      {/* About Section */}
-      <div className="container mx-auto">
-        <div className="lg:w-2/3 p-8">
-          <p className="text-2xl mb-2 text-muted-foreground">
-            Precision and Professionalism
-          </p>
-          <h2 className="text-4xl font-bold mb-8">
-            Expert <i className="font-normal">Audiovisual</i> Translation
-          </h2>
-          <p className="text-xl mb-4">
-            Bring your content to a global audience with our specialized subtitling services. With extensive experience in audiovisual translation, we handle diverse formats—including TV series, documentaries, feature films, theatre performances, and entire film festivals.
-          </p>
-          <p className="text-xl mb-8">
-            Whether your project is monolingual or a complex, multilingual production, our team ensures the narrative remains sharp and impactful across every frame.
-          </p>
-        </div>
-      </div>
-
-      {/* Services Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8" id="services">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our specialized audiovisual services
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Service Portfolio</h2>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 mb-8">
-              {services.map((service) => (
-                <ServiceCard
-                  key={service.id}
-                  label={service.label}
-                  description={service.description}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Why Us Section */}
-      <div className="bg-base-300">
-        <div className="container mx-auto">
-          <div className="p-8" id="why">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Why choose us
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Precision Meets Speed</h2>
-            <p className="text-xl mb-8 md:w-3/4 lg:w-2/3">
-              We leverage industry-leading software to guarantee flawless synchronization, strictly adhering to your specific timing and formatting requirements.
-            </p>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 mb-8">
-              <ServiceCard
-                label="Tone Adaptation"
-                description="We navigate all genres and registers with ease, ensuring that the tone of your original content—whether comedic, technical, or dramatic—is perfectly adapted for your target viewers."
-              />
-              <ServiceCard
-                label="Industry Turnaround"
-                description="We understand the tight turnaround times inherent in the entertainment industry and deliver high-quality subtitles without ever sacrificing accuracy."
-              />
-              <ServiceCard
-                label="Professional Workflow"
-                description="Partner with us for a seamless, professional viewing experience that respects both the art on screen and the constraints of your deadline."
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Specializations Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our expertise
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Diverse Format Experience</h2>
-            <p className="text-xl mb-8 lg:w-2/3">
-              We handle projects ranging from monolingual content to complex, multilingual productions across all formats and genres.
-            </p>
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-              {specializations.map((spec) => (
-                <LabeledEmoji key={spec.label} emoji={spec.emoji} label={spec.label} />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* CTA Section */}
-      <div className="hero-section h-full pb-16 text-white" style={{ background: 'linear-gradient(to top right, oklch(27% 0.041 260.031), oklch(44% 0.043 257.281), oklch(27% 0.046 192.524))' }}>
-        <div className="container mx-auto">
-          <div className="xl:w-2/3 p-8 pb-0 text-white">
-            <p className="text-2xl text-slate-400 mb-2">
-              Ready to bring your content to global audiences?
-            </p>
-            <h3 className="text-4xl font-bold mb-8">
-              Let&apos;s discuss your project
-            </h3>
-            <p className="text-xl mb-8 md:w-2/3">
-              Whether it&apos;s a single film or an entire film festival, we have the expertise to deliver seamless, professional subtitles.
-            </p>
+      {/* ── Hero ─────────────────────────────────────────────────── */}
+      <PageHero
+        navItems={navItems}
+        badge="Bridging borders through expert audiovisual translation"
+        title="Bringing Your Content to Global Audiences"
+        subtitle="From TV series to feature films and entire film festivals, we ensure the narrative remains sharp and impactful across every frame."
+        variant="full"
+        cta={
+          <div className="flex flex-col sm:flex-row gap-4">
             <button
-              className="btn btn-accent"
+              className="group relative inline-flex items-center gap-2 bg-amber-400 text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-amber-300 transition-all duration-300 hover:shadow-lg hover:shadow-amber-400/20"
               onClick={() => window.Beacon("open")}
             >
-              Contact us →
+              Get a free estimate
             </button>
+            <Link
+              href="/portfolio"
+              className="inline-flex items-center gap-2 border border-amber-400/40 text-amber-300 font-semibold px-8 py-4 rounded-xl hover:bg-amber-400/10 transition-all duration-300"
+            >
+              View Portfolio
+            </Link>
           </div>
-        </div>
-      </div>
+        }
+        features={heroFeatures}
+        backgroundElement={
+          <div className="absolute inset-0">
+            {/* Very dark cinematic gradient */}
+            <div className="absolute inset-0 bg-gradient-to-br from-black via-slate-950 to-slate-900" />
+            {/* Warm amber glow spots */}
+            <div className="absolute top-1/4 left-1/4 w-[500px] h-[500px] rounded-full bg-amber-500/8 blur-[160px]" />
+            <div className="absolute bottom-0 right-1/3 w-[400px] h-[400px] rounded-full bg-amber-600/6 blur-[140px]" />
+            <div className="absolute top-0 right-0 w-[300px] h-[300px] rounded-full bg-amber-400/5 blur-[120px]" />
+            {/* Film-grain overlay */}
+            <div
+              className="absolute inset-0 opacity-[0.04] pointer-events-none"
+              style={{
+                backgroundImage:
+                  "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E\")",
+                animation: "grain 0.5s steps(6) infinite",
+              }}
+            />
+          </div>
+        }
+        className="min-h-[90vh]"
+      />
 
-      {/* Footer */}
-      <div className="bg-slate-900">
-        <div className="container mx-auto p-8">
-          <Image
-            alt="Afterwords logo"
-            src="/logo.svg"
-            width={200}
-            height={50}
-            className="mb-8 w-1/3 md:w-1/4"
-          />
-          <div className="flex items-center">
-            <h3 className="text-white text-xl mr-4">Find us on social media</h3>
-            <a href="https://www.instagram.com/afterwordstranslations/" className="inline-block mr-4">
-              <Image
-                alt="Instagram logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/insta.svg"
-              />
-            </a>
-            <a href="https://www.linkedin.com/company/afterwordstranslations" className="inline-block mr-4">
-              <Image
-                alt="LinkedIn logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/in.png"
-              />
-            </a>
-            <a href="https://www.facebook.com/AfterWordstranslations" className="inline-block mr-4">
-              <Image
-                alt="Facebook logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/fb.png"
-              />
-            </a>
+      {/* ── About Section ────────────────────────────────────────── */}
+      <section className="py-20 md:py-28 bg-base-100">
+        <div className="container mx-auto px-8">
+          <div className="lg:w-2/3">
+            <SectionHeader
+              eyebrow="Precision and Professionalism"
+              title="Expert"
+              titleItalic="Audiovisual Translation"
+            />
+            <FadeIn delay={0.2} className="mt-8">
+              <p className="text-lg md:text-xl leading-relaxed text-base-content/70 mb-4">
+                Bring your content to a global audience with our specialized
+                subtitling services. With extensive experience in audiovisual
+                translation, we handle diverse formats—including TV series,
+                documentaries, feature films, theatre performances, and entire
+                film festivals.
+              </p>
+            </FadeIn>
+            <FadeIn delay={0.3}>
+              <p className="text-lg md:text-xl leading-relaxed text-base-content/70">
+                Whether your project is monolingual or a complex, multilingual
+                production, our team ensures the narrative remains sharp and
+                impactful across every frame.
+              </p>
+            </FadeIn>
           </div>
         </div>
-      </div>
+      </section>
+
+      {/* ── Services — Filmstrip Layout ──────────────────────────── */}
+      <section id="services" className="py-20 md:py-28 bg-slate-950 relative overflow-hidden">
+        {/* Subtle amber glow */}
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[300px] rounded-full bg-amber-500/5 blur-[140px]" />
+
+        <div className="container mx-auto px-8 relative z-10">
+          <SectionHeader
+            eyebrow="Our specialized audiovisual services"
+            title="Service Portfolio"
+            light
+          />
+
+          {/* Filmstrip frames — horizontal scroll on mobile, 2-col grid on desktop */}
+          <div className="mt-12 flex gap-6 overflow-x-auto pb-4 md:grid md:grid-cols-2 md:overflow-visible scrollbar-hide">
+            <StaggerContainer className="contents" staggerDelay={0.12}>
+              {services.map((service) => (
+                <StaggerItem key={service.id} className="min-w-[300px] md:min-w-0">
+                  <div className="relative h-full rounded-xl border border-amber-400/20 bg-slate-900/80 backdrop-blur-sm p-8 transition-all duration-300 hover:border-amber-400/40 hover:shadow-lg hover:shadow-amber-500/5 group">
+                    {/* Golden accent top bar — like a film frame edge */}
+                    <div className="absolute top-0 left-6 right-6 h-[2px] bg-gradient-to-r from-transparent via-amber-400/60 to-transparent" />
+                    {/* Sprocket holes */}
+                    <div className="absolute top-3 left-3 w-2 h-2 rounded-full border border-amber-400/30" />
+                    <div className="absolute top-3 right-3 w-2 h-2 rounded-full border border-amber-400/30" />
+                    <div className="absolute bottom-3 left-3 w-2 h-2 rounded-full border border-amber-400/30" />
+                    <div className="absolute bottom-3 right-3 w-2 h-2 rounded-full border border-amber-400/30" />
+
+                    <h3 className="text-xl font-bold text-white mb-3 group-hover:text-amber-300 transition-colors duration-300">
+                      {service.label}
+                    </h3>
+                    <p className="text-white/60 leading-relaxed">
+                      {service.description}
+                    </p>
+                  </div>
+                </StaggerItem>
+              ))}
+            </StaggerContainer>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Why Us — Cinema-themed Cards ─────────────────────────── */}
+      <section id="why" className="py-20 md:py-28 bg-base-200 relative overflow-hidden">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Why choose us"
+            title="Precision Meets Speed"
+            description="We leverage industry-leading software to guarantee flawless synchronization, strictly adhering to your specific timing and formatting requirements."
+          />
+
+          <StaggerContainer className="grid gap-8 grid-cols-1 md:grid-cols-3 mt-12">
+            {whyUs.map((item) => (
+              <StaggerItem key={item.label}>
+                <div className="relative bg-base-100 rounded-xl p-8 h-full border border-base-content/5 shadow-sm hover:shadow-md transition-shadow duration-300 group">
+                  {/* Film-slate top accent */}
+                  <div className="flex items-center gap-3 mb-5">
+                    <div className="w-10 h-8 rounded bg-slate-800 flex items-center justify-center">
+                      <div className="w-6 h-[2px] bg-amber-400" />
+                    </div>
+                    <div className="flex-1 h-[1px] bg-gradient-to-r from-amber-400/40 to-transparent" />
+                  </div>
+                  <h3 className="text-xl font-bold mb-3 group-hover:text-amber-600 transition-colors duration-300">
+                    {item.label}
+                  </h3>
+                  <p className="text-base-content/70 leading-relaxed">
+                    {item.description}
+                  </p>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* ── Specializations — Poster-style Tags ──────────────────── */}
+      <section className="py-20 md:py-28 bg-slate-950 relative overflow-hidden">
+        {/* Ambient glow */}
+        <div className="absolute bottom-0 right-0 w-[500px] h-[500px] rounded-full bg-amber-500/5 blur-[160px]" />
+
+        <div className="container mx-auto px-8 relative z-10">
+          <SectionHeader
+            eyebrow="Our expertise"
+            title="Diverse Format Experience"
+            description="We handle projects ranging from monolingual content to complex, multilingual productions across all formats and genres."
+            light
+          />
+
+          <StaggerContainer className="flex flex-wrap gap-5 mt-12">
+            {specializations.map((spec) => (
+              <StaggerItem key={spec.label}>
+                <motion.div
+                  whileHover={{ scale: 1.05, y: -4 }}
+                  transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                  className="relative px-8 py-5 rounded-xl border border-amber-400/25 bg-gradient-to-br from-slate-900 to-slate-800 cursor-default group"
+                >
+                  {/* Dramatic top glow on hover */}
+                  <div className="absolute inset-x-0 top-0 h-[1px] bg-gradient-to-r from-transparent via-amber-400/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                  <span className="text-3xl mr-3">{spec.emoji}</span>
+                  <span className="text-lg font-semibold text-white tracking-wide uppercase">
+                    {spec.label}
+                  </span>
+                </motion.div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* ── CTA ──────────────────────────────────────────────────── */}
+      <CTASection
+        eyebrow="Ready to bring your content to global audiences?"
+        title="Let's discuss your project"
+        description="Whether it's a single film or an entire film festival, we have the expertise to deliver seamless, professional subtitles."
+        buttonText="Contact us"
+      />
+
+      {/* ── Footer ───────────────────────────────────────────────── */}
+      <Footer />
     </div>
   );
 }

--- a/src/app/certified-translations/page.tsx
+++ b/src/app/certified-translations/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
-import { ServiceCard } from "~/components/Services";
-import LabeledEmoji from "~/components/LabeledEmoji";
-import { Header } from "~/components/Header";
+import { PageHero } from "~/components/PageHero";
+import { SectionHeader } from "~/components/SectionHeader";
+import { CTASection } from "~/components/CTASection";
+import { Footer } from "~/components/Footer";
+import { FadeIn } from "~/components/animations/FadeIn";
+import {
+  StaggerContainer,
+  StaggerItem,
+} from "~/components/animations/StaggerContainer";
 
 declare global {
   interface Window {
@@ -15,56 +20,102 @@ declare global {
 
 const services = [
   {
-    id: 1,
-    label: "Legal & Court Documents",
-    description: (
-      <>
-        <p className="mb-4">
-          Certified translations for contracts, powers of attorney, court rulings, and notarial deeds with full legal validity.
-        </p>
-      </>
-    )
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0012 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52l2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 01-2.031.352 5.988 5.988 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0l2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 01-2.031.352 5.989 5.989 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202L5.25 4.971z" />
+      </svg>
+    ),
+    title: "Legal & Court Documents",
+    description:
+      "Certified translations for contracts, powers of attorney, court rulings, and notarial deeds with full legal validity.",
   },
   {
-    id: 2,
-    label: "Civil & Public Authority Documents",
-    description: (
-      <>
-        <p className="mb-4">
-          Birth, marriage, and death certificates, criminal records, and all documents for submission to Greek public services and ministries.
-        </p>
-      </>
-    )
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z" />
+      </svg>
+    ),
+    title: "Civil & Public Authority Documents",
+    description:
+      "Birth, marriage, and death certificates, criminal records, and all documents for submission to Greek public services and ministries.",
   },
   {
-    id: 3,
-    label: "Educational & Academic Records",
-    description: (
-      <>
-        <p className="mb-4">
-          Diplomas, transcripts, and academic credentials certified for recognition by educational institutions and employers.
-        </p>
-      </>
-    )
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342M6.75 15a.75.75 0 100-1.5.75.75 0 000 1.5zm0 0v-3.675A55.378 55.378 0 0112 8.443m-7.007 11.55A5.981 5.981 0 006.75 15.75v-1.5" />
+      </svg>
+    ),
+    title: "Educational & Academic Records",
+    description:
+      "Diplomas, transcripts, and academic credentials certified for recognition by educational institutions and employers.",
   },
   {
-    id: 4,
-    label: "Immigration & Residency Permits",
-    description: (
-      <>
-        <p className="mb-4">
-          Visa applications, residence permits, and immigration documents translated and certified for Greek authorities.
-        </p>
-      </>
-    )
-  }
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" />
+      </svg>
+    ),
+    title: "Immigration & Residency Permits",
+    description:
+      "Visa applications, residence permits, and immigration documents translated and certified for Greek authorities.",
+  },
 ];
 
-const benefits = [
-  { emoji: "🎓", label: "Ionian University Graduates" },
-  { emoji: "🏛️", label: "PEEMPIP Certified Members" },
-  { emoji: "📋", label: "Official Association Seals" },
-  { emoji: "⚡", label: "Express Services Available" }
+const processSteps = [
+  {
+    step: "01",
+    title: "Submit",
+    description:
+      "Send us your documents via email or our contact form. We review and provide a quote within hours.",
+  },
+  {
+    step: "02",
+    title: "Translate",
+    description:
+      "Our certified translators handle your documents with precision, applying official seals and stamps.",
+  },
+  {
+    step: "03",
+    title: "Deliver",
+    description:
+      "Receive your certified translation digitally and via express courier, ready for submission.",
+  },
+];
+
+const credentials = [
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342M6.75 15a.75.75 0 100-1.5.75.75 0 000 1.5zm0 0v-3.675A55.378 55.378 0 0112 8.443m-7.007 11.55A5.981 5.981 0 006.75 15.75v-1.5" />
+      </svg>
+    ),
+    label: "Ionian University Graduates",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+      </svg>
+    ),
+    label: "PEEMPIP Certified Members",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+      </svg>
+    ),
+    label: "Official Association Seals",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+      </svg>
+    ),
+    label: "Express Services Available",
+  },
 ];
 
 export default function CertifiedTranslationsPage() {
@@ -77,225 +128,305 @@ export default function CertifiedTranslationsPage() {
   return (
     <div className="w-full bg-base-100 text-base-content">
       {/* Hero Section */}
-      <div className="hero-section bg-sl h-full pb-16">
-        <div>
-          <section className="relative w-full overflow-hidden bg-slate-900">
-            <div className="container mx-auto px-4 md:px-8"></div>
-            <Image
-              src="/bg-stamp.jpg"
-              alt="Professional certified translations"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-r from-slate-900 via-slate-900/90 to-transparent"></div>
-            <div className="relative z-10 h-full items-center px-8 lg:px-24">
-              <Header navItems={navItems} />
-              <div className="max-w-xl text-white mt-8">
-                <div>
-                  <h4 className="bg-accent text-accent-content text-xs shadow-lg rounded-3xl inline-block mb-8 px-4 py-2">
-                    Certified & Sworn Translations accepted by all Greek authorities
-                  </h4>
-                  <h1 className="text-5xl leading-tight font-bold mb-4">
-                    Official Greek Translations You Can Trust
-                  </h1>
-                  <p className="text-xl mb-16">
-                    Get certified translations from Ionian University graduates. Our sworn translations carry official association seals and are accepted by all public and private authorities in Greece and abroad.
-                  </p>
-                  <div className="flex flex-col sm:flex-row gap-4">
-                    <button
-                      className="btn btn-lg btn-accent"
-                      onClick={() => window.Beacon("open")}
-                    >
-                      Get a free quote
-                    </button>
-                    <Link
-                      href="/portfolio"
-                      className="btn btn-lg btn-outline btn-accent"
-                    >
-                      View Portfolio
-                    </Link>
-                  </div>
-                </div>
-              </div>
-              <div className="grid grid-cols-1 gap-8 md:grid-cols-3 my-16 text-white">
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Academic Excellence</h4>
-                  <p>Expert graduates of the Ionian University ensure linguistic precision and academic rigor for every document.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Official Certification</h4>
-                  <p>PEEMPIP members with official association seals for legal validity in all Greek public and private authorities.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">End-to-End Service</h4>
-                  <p>We handle translation, stamping, and delivery—including express shipping for urgent deadlines.</p>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
-
-      {/* About Section */}
-      <div className="container mx-auto">
-        <div className="lg:w-2/3 p-8">
-          <p className="text-2xl mb-2 text-muted-foreground">
-            Athens-based certified translation agency
-          </p>
-          <h2 className="text-4xl font-bold mb-8">
-            Professional Translations for <i className="font-normal">Legal, Civil & Educational</i> Documents
-          </h2>
-          <p className="text-xl mb-4">
-            We specialize in certified and sworn translations for documents requiring legal validity in Greece. Whether you need to submit paperwork to ministries, embassies, tax offices (DOY), or educational institutions, our translations meet all regulatory standards.
-          </p>
-          <p className="text-xl mb-8">
-            As proud members of the Panhellenic Association of Professional Translators Graduates of the Ionian University (PEEMPIP), our translations carry the official association seals required for complete legal acceptance.
-          </p>
-        </div>
-      </div>
-
-      {/* Services Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8" id="services">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our certified translation services
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Document Portfolio</h2>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 mb-8">
-              {services.map((service) => (
-                <ServiceCard
-                  key={service.id}
-                  label={service.label}
-                  description={service.description}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Why Us Section */}
-      <div className="bg-base-300">
-        <div className="container mx-auto">
-          <div className="p-8" id="why">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Why choose us
-            </p>
-            <h2 className="text-4xl font-bold mb-8">The Certified Translation Advantage</h2>
-            <p className="text-xl mb-8 md:w-3/4 lg:w-2/3">
-              We&apos;ve designed a seamless process to save you time: professional translation, official stamping, and final delivery—all handled by certified experts.
-            </p>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 mb-8">
-              <ServiceCard
-                label="Digital & Physical Delivery"
-                description="High-quality digital scans and express shipping of physical hard copies directly to your door."
-              />
-              <ServiceCard
-                label="Express Services"
-                description="Urgent deadline? We offer express translation services to ensure you never miss a submission date."
-              />
-              <ServiceCard
-                label="Universal Acceptance"
-                description="Translations accepted by all Greek public authorities, ministries, embassies, and private institutions."
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Benefits Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our credentials
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Certification & Professional Standing</h2>
-            <p className="text-xl mb-8 lg:w-2/3">
-              Every translation is handled by expert graduates of the Ionian University and carries the official seals required for legal validity.
-            </p>
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-              {benefits.map((benefit) => (
-                <LabeledEmoji key={benefit.label} emoji={benefit.emoji} label={benefit.label} />
-              ))}
-            </div>
-            <Image
-              alt="I work with SDL Trados Studio"
-              width={200}
-              height={50}
-              src="/trados.png"
-              className="sm:w-2/3 lg:w-2/5"
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* CTA Section */}
-      <div className="hero-section h-full pb-16 text-white" style={{ background: 'linear-gradient(to top right, oklch(27% 0.041 260.031), oklch(44% 0.043 257.281), oklch(27% 0.046 192.524))' }}>
-        <div className="container mx-auto">
-          <div className="xl:w-2/3 p-8 pb-0 text-white">
-            <p className="text-2xl text-slate-400 mb-2">
-              Ready to get your certified translation?
-            </p>
-            <h3 className="text-4xl font-bold mb-8">
-              Let&apos;s handle your official documents
-            </h3>
-            <p className="text-xl mb-8 md:w-2/3">
-              From legal paperwork to educational records, we deliver certified translations with full legal validity and express delivery options.
-            </p>
+      <PageHero
+        navItems={navItems}
+        badge="Certified & Sworn Translations accepted by all Greek authorities"
+        title="Official Greek Translations You Can Trust"
+        subtitle="Get certified translations from Ionian University graduates. Our sworn translations carry official association seals and are accepted by all public and private authorities in Greece and abroad."
+        cta={
+          <div className="flex flex-col sm:flex-row gap-4">
             <button
-              className="btn btn-accent"
+              className="group relative inline-flex items-center gap-2 bg-warm text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-warm-dark hover:text-white transition-all duration-300 hover:shadow-lg hover:shadow-warm/20"
               onClick={() => window.Beacon("open")}
             >
-              Contact us →
+              Get a free quote
+              <svg
+                className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 7l5 5m0 0l-5 5m5-5H6"
+                />
+              </svg>
             </button>
+            <Link
+              href="/portfolio"
+              className="inline-flex items-center gap-2 px-8 py-4 rounded-xl border border-white/20 text-white font-semibold hover:bg-white/10 transition-all duration-300"
+            >
+              View Portfolio
+            </Link>
+          </div>
+        }
+        features={[
+          {
+            title: "Academic Excellence",
+            description:
+              "Expert graduates of the Ionian University ensure linguistic precision and academic rigor for every document.",
+          },
+          {
+            title: "Official Certification",
+            description:
+              "PEEMPIP members with official association seals for legal validity in all Greek public and private authorities.",
+          },
+          {
+            title: "End-to-End Service",
+            description:
+              "We handle translation, stamping, and delivery\u2014including express shipping for urgent deadlines.",
+          },
+        ]}
+        backgroundElement={
+          <>
+            {/* Warm gold/cream gradient */}
+            <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-[#2a2520] to-slate-900" />
+            {/* Subtle dot pattern suggesting official documents */}
+            <svg
+              className="absolute inset-0 w-full h-full opacity-[0.04]"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <pattern
+                  id="dot-pattern"
+                  x="0"
+                  y="0"
+                  width="24"
+                  height="24"
+                  patternUnits="userSpaceOnUse"
+                >
+                  <circle cx="2" cy="2" r="1" fill="#d4a574" />
+                </pattern>
+              </defs>
+              <rect width="100%" height="100%" fill="url(#dot-pattern)" />
+            </svg>
+            {/* Gold accent glow */}
+            <div className="absolute top-1/4 right-0 w-[500px] h-[500px] rounded-full bg-[#c9a96e]/10 blur-[150px]" />
+            <div className="absolute bottom-0 left-1/4 w-80 h-80 rounded-full bg-warm/5 blur-[100px]" />
+          </>
+        }
+        variant="full"
+      />
+
+      {/* About Section */}
+      <section className="py-20 md:py-28">
+        <div className="container mx-auto px-8">
+          <div className="max-w-3xl">
+            <SectionHeader
+              eyebrow="Athens-based certified translation agency"
+              title="Professional Translations for"
+              titleItalic="Legal, Civil & Educational Documents"
+            />
+            <FadeIn delay={0.3}>
+              <p className="text-lg md:text-xl leading-relaxed text-base-content/70 mt-8">
+                We specialize in certified and sworn translations for documents
+                requiring legal validity in Greece. Whether you need to submit
+                paperwork to ministries, embassies, tax offices (DOY), or
+                educational institutions, our translations meet all regulatory
+                standards.
+              </p>
+            </FadeIn>
+            <FadeIn delay={0.4}>
+              <p className="text-lg md:text-xl leading-relaxed text-base-content/70 mt-4">
+                As proud members of the Panhellenic Association of Professional
+                Translators Graduates of the Ionian University (PEEMPIP), our
+                translations carry the official association seals required for
+                complete legal acceptance.
+              </p>
+            </FadeIn>
           </div>
         </div>
-      </div>
+      </section>
+
+      {/* Services Section — Document-style checklist layout */}
+      <section className="py-20 md:py-28 bg-base-200/50" id="services">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our certified translation services"
+            title="Document Portfolio"
+          />
+
+          <StaggerContainer
+            className="mt-16 max-w-3xl space-y-0 divide-y divide-base-300"
+            staggerDelay={0.12}
+          >
+            {services.map((service) => (
+              <StaggerItem key={service.title}>
+                <div className="group flex items-start gap-6 py-8 first:pt-0 last:pb-0">
+                  {/* Seal / checkmark icon */}
+                  <div className="flex-shrink-0 w-12 h-12 rounded-full bg-warm/10 border border-warm/20 flex items-center justify-center text-warm group-hover:bg-warm group-hover:text-slate-900 transition-all duration-300">
+                    {service.icon}
+                  </div>
+                  <div>
+                    <h3 className="font-[family-name:var(--font-display)] text-xl font-semibold text-base-content mb-2">
+                      {service.title}
+                    </h3>
+                    <p className="text-base-content/60 leading-relaxed">
+                      {service.description}
+                    </p>
+                  </div>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* Process Section — 3-step animated flow */}
+      <section className="py-20 md:py-28">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="How it works"
+            title="Three Steps to Your"
+            titleItalic="Certified Translation"
+            description="We've designed a seamless process to save you time: professional translation, official stamping, and final delivery\u2014all handled by certified experts."
+            align="center"
+          />
+
+          <div className="mt-20 relative max-w-4xl mx-auto">
+            {/* Connecting line */}
+            <div className="hidden md:block absolute top-16 left-[16.67%] right-[16.67%] h-px bg-gradient-to-r from-warm/0 via-warm/40 to-warm/0" />
+
+            <StaggerContainer
+              className="grid grid-cols-1 md:grid-cols-3 gap-12 md:gap-8"
+              staggerDelay={0.2}
+            >
+              {processSteps.map((step) => (
+                <StaggerItem key={step.step} className="text-center">
+                  <div className="relative inline-flex items-center justify-center w-32 h-32 mx-auto mb-8">
+                    {/* Outer ring */}
+                    <div className="absolute inset-0 rounded-full border-2 border-warm/20" />
+                    {/* Inner circle */}
+                    <div className="w-20 h-20 rounded-full bg-warm/10 flex items-center justify-center">
+                      <span className="font-[family-name:var(--font-display)] text-3xl font-bold text-warm">
+                        {step.step}
+                      </span>
+                    </div>
+                  </div>
+                  <h3 className="font-[family-name:var(--font-display)] text-2xl font-bold text-base-content mb-3">
+                    {step.title}
+                  </h3>
+                  <p className="text-base-content/60 leading-relaxed max-w-xs mx-auto">
+                    {step.description}
+                  </p>
+                </StaggerItem>
+              ))}
+            </StaggerContainer>
+          </div>
+        </div>
+      </section>
+
+      {/* Benefits Section */}
+      <section className="py-20 md:py-28 bg-base-200/50" id="why">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Why choose us"
+            title="The Certified Translation Advantage"
+          />
+
+          <StaggerContainer
+            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 mt-16"
+            staggerDelay={0.1}
+          >
+            <StaggerItem>
+              <div className="bg-base-100 rounded-2xl p-8 border border-base-300 h-full hover:border-warm/30 transition-colors duration-300">
+                <div className="w-10 h-10 rounded-lg bg-warm/10 flex items-center justify-center text-warm mb-5">
+                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 3.75H6.912a2.25 2.25 0 00-2.15 1.588L2.35 13.177a2.25 2.25 0 00-.1.661V18a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 00-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 012.012 1.244l.256.512a2.25 2.25 0 002.013 1.244h3.218a2.25 2.25 0 002.013-1.244l.256-.512a2.25 2.25 0 012.013-1.244h3.859M12 3v8.25m0 0l-3-3m3 3l3-3" />
+                  </svg>
+                </div>
+                <h3 className="font-[family-name:var(--font-display)] text-xl font-semibold text-base-content mb-3">
+                  Digital & Physical Delivery
+                </h3>
+                <p className="text-base-content/60 leading-relaxed">
+                  High-quality digital scans and express shipping of physical
+                  hard copies directly to your door.
+                </p>
+              </div>
+            </StaggerItem>
+            <StaggerItem>
+              <div className="bg-base-100 rounded-2xl p-8 border border-base-300 h-full hover:border-warm/30 transition-colors duration-300">
+                <div className="w-10 h-10 rounded-lg bg-warm/10 flex items-center justify-center text-warm mb-5">
+                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+                  </svg>
+                </div>
+                <h3 className="font-[family-name:var(--font-display)] text-xl font-semibold text-base-content mb-3">
+                  Express Services
+                </h3>
+                <p className="text-base-content/60 leading-relaxed">
+                  Urgent deadline? We offer express translation services to
+                  ensure you never miss a submission date.
+                </p>
+              </div>
+            </StaggerItem>
+            <StaggerItem>
+              <div className="bg-base-100 rounded-2xl p-8 border border-base-300 h-full hover:border-warm/30 transition-colors duration-300">
+                <div className="w-10 h-10 rounded-lg bg-warm/10 flex items-center justify-center text-warm mb-5">
+                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z" />
+                  </svg>
+                </div>
+                <h3 className="font-[family-name:var(--font-display)] text-xl font-semibold text-base-content mb-3">
+                  Universal Acceptance
+                </h3>
+                <p className="text-base-content/60 leading-relaxed">
+                  Translations accepted by all Greek public authorities,
+                  ministries, embassies, and private institutions.
+                </p>
+              </div>
+            </StaggerItem>
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* Credentials — Horizontal trust badge bar */}
+      <section className="py-16 border-y border-base-300">
+        <div className="container mx-auto px-8">
+          <FadeIn>
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-warm-dark text-center mb-10">
+              Certification & Professional Standing
+            </p>
+          </FadeIn>
+          <FadeIn delay={0.1}>
+            <p className="text-center text-base-content/70 text-lg max-w-2xl mx-auto mb-12">
+              Every translation is handled by expert graduates of the Ionian
+              University and carries the official seals required for legal
+              validity.
+            </p>
+          </FadeIn>
+          <StaggerContainer
+            className="flex flex-wrap items-center justify-center gap-x-12 gap-y-6"
+            staggerDelay={0.1}
+          >
+            {credentials.map((cred) => (
+              <StaggerItem key={cred.label}>
+                <div className="flex items-center gap-3 text-base-content/70">
+                  <div className="w-9 h-9 rounded-full bg-warm/10 flex items-center justify-center text-warm flex-shrink-0">
+                    {cred.icon}
+                  </div>
+                  <span className="text-sm font-medium whitespace-nowrap">
+                    {cred.label}
+                  </span>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <CTASection
+        eyebrow="Ready to get your certified translation?"
+        title="Let's handle your official documents"
+        description="From legal paperwork to educational records, we deliver certified translations with full legal validity and express delivery options."
+        buttonText="Contact us"
+      />
 
       {/* Footer */}
-      <div className="bg-slate-900">
-        <div className="container mx-auto p-8">
-          <Image
-            alt="Afterwords logo"
-            src="/logo.svg"
-            width={200}
-            height={50}
-            className="mb-8 w-1/3 md:w-1/4"
-          />
-          <div className="flex items-center">
-            <h3 className="text-white text-xl mr-4">Find us on social media</h3>
-            <a href="https://www.instagram.com/afterwordstranslations/" className="inline-block mr-4">
-              <Image
-                alt="Instagram logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/insta.svg"
-              />
-            </a>
-            <a href="https://www.linkedin.com/company/afterwordstranslations" className="inline-block mr-4">
-              <Image
-                alt="LinkedIn logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/in.png"
-              />
-            </a>
-            <a href="https://www.facebook.com/AfterWordstranslations" className="inline-block mr-4">
-              <Image
-                alt="Facebook logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/fb.png"
-              />
-            </a>
-          </div>
-        </div>
-      </div>
+      <Footer />
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,19 @@
 
 @plugin "daisyui";
 
+/* Card surface background that adapts per theme */
+.card-surface {
+  background-color: var(--color-base-200);
+}
+
+[data-theme="afterwords-dark"] .card-surface {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+[data-theme="afterwords-dark"] .card-surface:hover {
+  background-color: rgba(255, 255, 255, 0.07);
+}
+
 @theme {
   --font-sans: var(--font-body), "Noto Sans", sans-serif;
   --font-display: var(--font-display), "Playfair Display", serif;
@@ -49,9 +62,9 @@
   name: "afterwords-dark";
   prefersdark: true;
   color-scheme: "dark";
-  --color-base-100: oklch(28.822% 0.022 277.508);
-  --color-base-200: oklch(26.805% 0.02 277.508);
-  --color-base-300: oklch(24.787% 0.019 277.508);
+  --color-base-100: oklch(18% 0.04 255);
+  --color-base-200: oklch(15% 0.035 255);
+  --color-base-300: oklch(26% 0.04 255);
   --color-base-content: oklch(97.747% 0.007 106.545);
   --color-primary: oklch(91.372% 0.051 257.57);
   --color-primary-content: oklch(91.372% 0.051 257.57);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,14 @@
 
 @plugin "daisyui";
 
+@theme {
+  --font-sans: var(--font-body), "Noto Sans", sans-serif;
+  --font-display: var(--font-display), "Playfair Display", serif;
+  --color-warm: oklch(82% 0.12 75);
+  --color-warm-subtle: oklch(94% 0.04 70);
+  --color-warm-dark: oklch(70% 0.1 60);
+}
+
 @plugin "daisyui/theme" {
   name: "afterwords-light";
   default: true;

--- a/src/app/interpreting/page.tsx
+++ b/src/app/interpreting/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
-import { ServiceCard } from "~/components/Services";
-import LabeledEmoji from "~/components/LabeledEmoji";
-import { Header } from "~/components/Header";
+import { motion } from "framer-motion";
+import { PageHero } from "~/components/PageHero";
+import { SectionHeader } from "~/components/SectionHeader";
+import { CTASection } from "~/components/CTASection";
+import { Footer } from "~/components/Footer";
+import { FadeIn } from "~/components/animations/FadeIn";
+import {
+  StaggerContainer,
+  StaggerItem,
+} from "~/components/animations/StaggerContainer";
 
 declare global {
   interface Window {
@@ -15,57 +21,145 @@ declare global {
 
 const services = [
   {
-    id: 1,
     label: "Corporate Summits & Keynotes",
-    description: (
-      <>
-        <p className="mb-4">
-          High-energy, stage-ready simultaneous interpreting for international conferences and corporate summits.
-        </p>
-      </>
-    )
+    description:
+      "High-energy, stage-ready simultaneous interpreting for international conferences and corporate summits.",
+    direction: "left" as const,
   },
   {
-    id: 2,
     label: "Board Meetings & Negotiations",
-    description: (
-      <>
-        <p className="mb-4">
-          Discreet, high-level consecutive interpreting for executive sessions and high-stakes negotiations.
-        </p>
-      </>
-    )
+    description:
+      "Discreet, high-level consecutive interpreting for executive sessions and high-stakes negotiations.",
+    direction: "right" as const,
   },
   {
-    id: 3,
     label: "Technical Readiness",
-    description: (
-      <>
-        <p className="mb-4">
-          Deep briefing on your specific industry terminology to ensure accurate communication of complex concepts.
-        </p>
-      </>
-    )
+    description:
+      "Deep briefing on your specific industry terminology to ensure accurate communication of complex concepts.",
+    direction: "left" as const,
   },
   {
-    id: 4,
     label: "Event Integration",
-    description: (
-      <>
-        <p className="mb-4">
-          Elite linguistic talent that integrates flawlessly with your event's technical setup and production requirements.
-        </p>
-      </>
-    )
-  }
+    description:
+      "Elite linguistic talent that integrates flawlessly with your event's technical setup and production requirements.",
+    direction: "right" as const,
+  },
+];
+
+const whyUsCards = [
+  {
+    title: "Punctuality & Readiness",
+    description:
+      "We prioritize punctuality and professional readiness, ensuring your event starts on schedule.",
+    icon: (
+      <svg
+        className="w-8 h-8"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: "Professional Discretion",
+    description:
+      "Boutique partnership that values your brand's reputation with complete confidentiality.",
+    icon: (
+      <svg
+        className="w-8 h-8"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+        />
+      </svg>
+    ),
+  },
+  {
+    title: "Human-Led Excellence",
+    description:
+      "Professional verbal communication that resonates across every language barrier—human to human.",
+    icon: (
+      <svg
+        className="w-8 h-8"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"
+        />
+      </svg>
+    ),
+  },
 ];
 
 const specializations = [
-  { emoji: "🏢", label: "Corporate" },
-  { emoji: "⚖️", label: "Legal" },
-  { emoji: "🎯", label: "Diplomatic" },
-  { emoji: "🎤", label: "Live Events" }
+  { label: "Corporate", color: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30" },
+  { label: "Legal", color: "bg-teal-500/15 text-teal-300 border-teal-500/30" },
+  { label: "Diplomatic", color: "bg-cyan-500/15 text-cyan-300 border-cyan-500/30" },
+  { label: "Live Events", color: "bg-green-500/15 text-green-300 border-green-500/30" },
 ];
+
+/* Animated gradient mesh background for the hero */
+const HeroBackground = () => (
+  <>
+    <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-emerald-950 to-teal-950" />
+    {/* Animated gradient mesh blobs */}
+    <motion.div
+      className="absolute top-1/4 -left-32 w-[500px] h-[500px] rounded-full bg-emerald-600/20 blur-[120px]"
+      animate={{ x: [0, 40, 0], y: [0, -30, 0] }}
+      transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
+    />
+    <motion.div
+      className="absolute bottom-0 right-0 w-[400px] h-[400px] rounded-full bg-teal-500/15 blur-[100px]"
+      animate={{ x: [0, -30, 0], y: [0, 20, 0] }}
+      transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
+    />
+    <motion.div
+      className="absolute top-1/3 right-1/4 w-[300px] h-[300px] rounded-full bg-cyan-500/10 blur-[80px]"
+      animate={{ scale: [1, 1.2, 1], opacity: [0.3, 0.5, 0.3] }}
+      transition={{ duration: 6, repeat: Infinity, ease: "easeInOut" }}
+    />
+    {/* Speech bubble SVG motifs */}
+    <svg
+      className="absolute top-20 right-16 w-24 h-24 text-white/[0.04]"
+      viewBox="0 0 100 100"
+      fill="currentColor"
+    >
+      <path d="M50 10c22 0 40 15 40 33s-18 33-40 33c-5 0-10-1-14-2l-16 10 4-14C14 62 10 52 10 43c0-18 18-33 40-33z" />
+    </svg>
+    <svg
+      className="absolute bottom-32 left-12 w-16 h-16 text-white/[0.04] rotate-12"
+      viewBox="0 0 100 100"
+      fill="currentColor"
+    >
+      <path d="M50 10c22 0 40 15 40 33s-18 33-40 33c-5 0-10-1-14-2l-16 10 4-14C14 62 10 52 10 43c0-18 18-33 40-33z" />
+    </svg>
+    <svg
+      className="absolute top-1/2 right-1/3 w-20 h-20 text-white/[0.03] -rotate-6"
+      viewBox="0 0 100 100"
+      fill="currentColor"
+    >
+      <path d="M50 10c22 0 40 15 40 33s-18 33-40 33c-5 0-10-1-14-2l-16 10 4-14C14 62 10 52 10 43c0-18 18-33 40-33z" />
+    </svg>
+  </>
+);
 
 export default function InterpretingPage() {
   const navItems = [
@@ -77,218 +171,222 @@ export default function InterpretingPage() {
   return (
     <div className="w-full bg-base-100 text-base-content">
       {/* Hero Section */}
-      <div className="hero-section bg-sl h-full pb-16">
-        <div>
-          <section className="relative w-full overflow-hidden bg-slate-900">
-            <div className="container mx-auto px-4 md:px-8"></div>
-            <Image
-              src="/bg-interpreting.jpg"
-              alt="Professional conference interpreting"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-r from-slate-900 via-slate-900/90 to-transparent"></div>
-            <div className="relative z-10 h-full items-center px-8 lg:px-24">
-              <Header navItems={navItems} />
-              <div className="max-w-xl text-white mt-8">
-                <div>
-                  <h4 className="bg-accent text-accent-content text-xs shadow-lg rounded-3xl inline-block mb-8 px-4 py-2">
-                    Athens-based agency specializing in live event interpretation
-                  </h4>
-                  <h1 className="text-5xl leading-tight font-bold mb-4">
-                    High-Impact Interpreting: The Voice of Your Global Event
-                  </h1>
-                  <p className="text-xl mb-16">
-                    In live events, there are no "second takes." We provide ready-for-stage interpreters for international summits and high-stakes board meetings.
-                  </p>
-                  <div className="flex flex-col sm:flex-row gap-4">
-                    <button
-                      className="btn btn-lg btn-accent"
-                      onClick={() => window.Beacon("open")}
-                    >
-                      Get a free estimate
-                    </button>
-                    <Link
-                      href="/portfolio"
-                      className="btn btn-lg btn-outline btn-accent"
-                    >
-                      View Portfolio
-                    </Link>
-                  </div>
-                </div>
-              </div>
-              <div className="grid grid-cols-1 gap-8 md:grid-cols-3 my-16 text-white">
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Simultaneous & Consecutive</h4>
-                  <p>Expert interpretation ensuring your speaker's charisma and nuances aren't lost in translation.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Bidirectional Mastery</h4>
-                  <p>Greek and English fluency guaranteeing every attendee—local or foreign—remains fully engaged.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Stage-Ready Professionals</h4>
-                  <p>Elite interpreters with the poise and stamina for complex topics and spontaneous Q&A sessions.</p>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
-
-      {/* About Section */}
-      <div className="container mx-auto">
-        <div className="lg:w-2/3 p-8">
-          <p className="text-2xl mb-2 text-muted-foreground">
-            Expertise Across Registers
-          </p>
-          <h2 className="text-4xl font-bold mb-8">
-            From Boardrooms to <i className="font-normal">Summits</i>
-          </h2>
-          <p className="text-xl mb-4">
-            Precision requires more than fluency; it requires deep subject matter expertise. Our team thrives in corporate, legal, and diplomatic environments, adapting seamlessly to your specific professional register.
-          </p>
-          <p className="text-xl mb-8">
-            We eliminate the risks of "Bad Interpretation"—such as brand damage or miscommunication—through meticulous preparation. We bring the poise and stamina needed to handle complex technical topics and spontaneous Q&A sessions with absolute composure.
-          </p>
-        </div>
-      </div>
-
-      {/* Services Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8" id="services">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our interpreting services
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Service Portfolio</h2>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 mb-8">
-              {services.map((service) => (
-                <ServiceCard
-                  key={service.id}
-                  label={service.label}
-                  description={service.description}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Why Us Section */}
-      <div className="bg-base-300">
-        <div className="container mx-auto">
-          <div className="p-8" id="why">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Why choose us
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Reliability and Flexibility</h2>
-            <p className="text-xl mb-8 md:w-3/4 lg:w-2/3">
-              Your trusted talent partner for elite linguistic services that integrate flawlessly with your event's technical setup.
-            </p>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 mb-8">
-              <ServiceCard
-                label="Punctuality & Readiness"
-                description="We prioritize punctuality and professional readiness, ensuring your event starts on schedule."
-              />
-              <ServiceCard
-                label="Professional Discretion"
-                description="Boutique partnership that values your brand's reputation with complete confidentiality."
-              />
-              <ServiceCard
-                label="Human-Led Excellence"
-                description="Professional verbal communication that resonates across every language barrier—human to human."
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Specializations Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our expertise
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Deep Specialization</h2>
-            <p className="text-xl mb-8 lg:w-2/3">
-              Whether it's a private executive session or a large-scale conference, we deliver human-led, professional verbal communication across language barriers.
-            </p>
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-              {specializations.map((spec) => (
-                <LabeledEmoji key={spec.label} emoji={spec.emoji} label={spec.label} />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* CTA Section */}
-      <div className="hero-section h-full pb-16 text-white" style={{ background: 'linear-gradient(to top right, oklch(27% 0.041 260.031), oklch(44% 0.043 257.281), oklch(27% 0.046 192.524))' }}>
-        <div className="container mx-auto">
-          <div className="xl:w-2/3 p-8 pb-0 text-white">
-            <p className="text-2xl text-slate-400 mb-2">
-              Ready to discuss your interpreting needs?
-            </p>
-            <h3 className="text-4xl font-bold mb-8">
-              Let's talk about your event
-            </h3>
-            <p className="text-xl mb-8 md:w-2/3">
-              Whether it's a private executive session or a large-scale conference, we have the expertise and elite talent to deliver excellence.
-            </p>
+      <PageHero
+        navItems={navItems}
+        badge="Athens-based agency specializing in live event interpretation"
+        title="High-Impact Interpreting: The Voice of Your Global Event"
+        subtitle='In live events, there are no "second takes." We provide ready-for-stage interpreters for international summits and high-stakes board meetings.'
+        cta={
+          <div className="flex flex-col sm:flex-row gap-4">
             <button
-              className="btn btn-accent"
+              className="group relative inline-flex items-center gap-2 bg-warm text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-warm-dark hover:text-white transition-all duration-300 hover:shadow-lg hover:shadow-warm/20"
               onClick={() => window.Beacon("open")}
             >
-              Contact us →
+              Get a free estimate
+              <svg
+                className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 7l5 5m0 0l-5 5m5-5H6"
+                />
+              </svg>
             </button>
+            <Link
+              href="/portfolio"
+              className="inline-flex items-center gap-2 border border-white/20 text-white font-semibold px-8 py-4 rounded-xl hover:bg-white/10 transition-all duration-300"
+            >
+              View Portfolio
+            </Link>
+          </div>
+        }
+        features={[
+          {
+            title: "Simultaneous & Consecutive",
+            description:
+              "Expert interpretation ensuring your speaker's charisma and nuances aren't lost in translation.",
+          },
+          {
+            title: "Bidirectional Mastery",
+            description:
+              "Greek and English fluency guaranteeing every attendee—local or foreign—remains fully engaged.",
+          },
+          {
+            title: "Stage-Ready Professionals",
+            description:
+              "Elite interpreters with the poise and stamina for complex topics and spontaneous Q&A sessions.",
+          },
+        ]}
+        backgroundElement={<HeroBackground />}
+        variant="full"
+      />
+
+      {/* About Section */}
+      <section className="py-20 md:py-28">
+        <div className="container mx-auto px-8">
+          <div className="lg:w-2/3">
+            <SectionHeader
+              eyebrow="Expertise Across Registers"
+              title="From Boardrooms to"
+              titleItalic="Summits"
+            />
+            <FadeIn delay={0.2}>
+              <p className="text-lg md:text-xl leading-relaxed text-base-content/70 mt-8">
+                Precision requires more than fluency; it requires deep subject
+                matter expertise. Our team thrives in corporate, legal, and
+                diplomatic environments, adapting seamlessly to your specific
+                professional register.
+              </p>
+            </FadeIn>
+            <FadeIn delay={0.3}>
+              <p className="text-lg md:text-xl leading-relaxed text-base-content/70 mt-4">
+                We eliminate the risks of &ldquo;Bad Interpretation&rdquo;&mdash;such as
+                brand damage or miscommunication&mdash;through meticulous
+                preparation. We bring the poise and stamina needed to handle
+                complex technical topics and spontaneous Q&amp;A sessions with
+                absolute composure.
+              </p>
+            </FadeIn>
           </div>
         </div>
-      </div>
+      </section>
+
+      {/* Services Section — Conversation-style speech bubbles */}
+      <section className="py-20 md:py-28 bg-base-200/50" id="services">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our interpreting services"
+            title="Service Portfolio"
+            align="center"
+          />
+
+          <div className="mt-16 max-w-3xl mx-auto space-y-8">
+            {services.map((service, i) => {
+              const isLeft = service.direction === "left";
+              return (
+                <FadeIn
+                  key={service.label}
+                  direction={service.direction}
+                  delay={i * 0.1}
+                >
+                  <div
+                    className={`flex ${isLeft ? "justify-start" : "justify-end"}`}
+                  >
+                    <div
+                      className={`relative max-w-lg p-6 rounded-2xl ${
+                        isLeft
+                          ? "bg-emerald-600/10 border border-emerald-500/20 rounded-bl-sm"
+                          : "bg-teal-600/10 border border-teal-500/20 rounded-br-sm"
+                      }`}
+                    >
+                      {/* Speech bubble tail */}
+                      <div
+                        className={`absolute bottom-0 w-4 h-4 ${
+                          isLeft
+                            ? "-left-1 bg-emerald-600/10 border-l border-b border-emerald-500/20"
+                            : "-right-1 bg-teal-600/10 border-r border-b border-teal-500/20"
+                        }`}
+                        style={{
+                          clipPath: isLeft
+                            ? "polygon(100% 0, 0% 100%, 100% 100%)"
+                            : "polygon(0 0, 100% 100%, 0 100%)",
+                        }}
+                      />
+                      <h3 className="text-lg font-bold mb-2 text-base-content">
+                        {service.label}
+                      </h3>
+                      <p className="text-base-content/70 leading-relaxed">
+                        {service.description}
+                      </p>
+                    </div>
+                  </div>
+                </FadeIn>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Us Section — Cards with hover + stagger */}
+      <section className="py-20 md:py-28" id="why">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Why choose us"
+            title="Reliability and Flexibility"
+            description="Your trusted talent partner for elite linguistic services that integrate flawlessly with your event's technical setup."
+          />
+
+          <StaggerContainer
+            staggerDelay={0.15}
+            className="grid gap-8 grid-cols-1 md:grid-cols-3 mt-16"
+          >
+            {whyUsCards.map((card) => (
+              <StaggerItem key={card.title}>
+                <motion.div
+                  className="group relative p-8 rounded-2xl border border-base-300 bg-base-100 hover:border-emerald-500/30 transition-all duration-300 h-full"
+                  whileHover={{ y: -4, boxShadow: "0 20px 40px -12px rgba(16, 185, 129, 0.1)" }}
+                >
+                  <div className="w-14 h-14 rounded-xl bg-emerald-500/10 text-emerald-500 flex items-center justify-center mb-6 group-hover:bg-emerald-500/20 transition-colors duration-300">
+                    {card.icon}
+                  </div>
+                  <h3 className="text-xl font-bold mb-3 text-base-content">
+                    {card.title}
+                  </h3>
+                  <p className="text-base-content/70 leading-relaxed">
+                    {card.description}
+                  </p>
+                </motion.div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* Specializations — Horizontal pills */}
+      <section className="py-20 md:py-28 bg-slate-900 text-white">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our expertise"
+            title="Deep Specialization"
+            description="Whether it's a private executive session or a large-scale conference, we deliver human-led, professional verbal communication across language barriers."
+            light
+          />
+
+          <FadeIn delay={0.2}>
+            <div className="flex flex-wrap gap-4 mt-12">
+              {specializations.map((spec, i) => (
+                <motion.span
+                  key={spec.label}
+                  className={`inline-flex items-center px-6 py-3 rounded-full text-sm font-semibold border ${spec.color} cursor-default`}
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  whileInView={{ opacity: 1, scale: 1 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: 0.3 + i * 0.1, duration: 0.4 }}
+                  whileHover={{ scale: 1.05 }}
+                >
+                  {spec.label}
+                </motion.span>
+              ))}
+            </div>
+          </FadeIn>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <CTASection
+        eyebrow="Ready to discuss your interpreting needs?"
+        title="Let's talk about your event"
+        description="Whether it's a private executive session or a large-scale conference, we have the expertise and elite talent to deliver excellence."
+        buttonText="Contact us"
+      />
 
       {/* Footer */}
-      <div className="bg-slate-900">
-        <div className="container mx-auto p-8">
-          <Image
-            alt="Afterwords logo"
-            src="/logo.svg"
-            width={200}
-            height={50}
-            className="mb-8 w-1/3 md:w-1/4"
-          />
-          <div className="flex items-center">
-            <h3 className="text-white text-xl mr-4">Find us on social media</h3>
-            <a href="https://www.instagram.com/afterwordstranslations/" className="inline-block mr-4">
-              <Image
-                alt="Instagram logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/insta.svg"
-              />
-            </a>
-            <a href="https://www.linkedin.com/company/afterwordstranslations" className="inline-block mr-4">
-              <Image
-                alt="LinkedIn logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/in.png"
-              />
-            </a>
-            <a href="https://www.facebook.com/AfterWordstranslations" className="inline-block mr-4">
-              <Image
-                alt="Facebook logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/fb.png"
-              />
-            </a>
-          </div>
-        </div>
-      </div>
+      <Footer />
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={noto.className}>{children}</body>
+      <body className={`${noto.variable} ${playfair.variable}`}>{children}</body>
       {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
         <>
           <Script

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { Noto_Sans } from "next/font/google";
+import { Noto_Sans, Playfair_Display } from "next/font/google";
 import Script from "next/script";
 
-// If loading a variable font, you don't need to specify the font weight
-const noto = Noto_Sans({ subsets: ["latin", "greek"] });
+const noto = Noto_Sans({ subsets: ["latin", "greek"], variable: "--font-body" });
+const playfair = Playfair_Display({ subsets: ["latin"], variable: "--font-display" });
 
 export const metadata: Metadata = {
   title:

--- a/src/app/maritime-translation/page.tsx
+++ b/src/app/maritime-translation/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
-import { ServiceCard } from "~/components/Services";
-import LabeledEmoji from "~/components/LabeledEmoji";
-import { Header } from "~/components/Header";
+import { motion } from "framer-motion";
+import { PageHero } from "~/components/PageHero";
+import { SectionHeader } from "~/components/SectionHeader";
+import { CTASection } from "~/components/CTASection";
+import { Footer } from "~/components/Footer";
+import { FadeIn } from "~/components/animations/FadeIn";
+import {
+  StaggerContainer,
+  StaggerItem,
+} from "~/components/animations/StaggerContainer";
 
 declare global {
   interface Window {
@@ -13,49 +19,166 @@ declare global {
   }
 }
 
+/* ───────── Data ───────── */
+
 const services = [
   {
     id: 1,
     label: "Legal & Claims",
-    description: (
-      <>
-        <p className="mb-4">
-          Precise translation for Charter Party disputes, Bills of Lading, and LMAA arbitration. We provide the linguistic security required for high-stakes maritime litigation.
-        </p>
-      </>
-    )
+    description:
+      "Precise translation for Charter Party disputes, Bills of Lading, and LMAA arbitration. We provide the linguistic security required for high-stakes maritime litigation.",
   },
   {
     id: 2,
     label: "Crewing & Operations",
-    description: (
-      <>
-        <p className="mb-4">
-          Ensuring compliance for Seafarer Employment Agreements (SEA), PEME medicals, and STCW certifications across our core European language sets.
-        </p>
-      </>
-    )
+    description:
+      "Ensuring compliance for Seafarer Employment Agreements (SEA), PEME medicals, and STCW certifications across our core European language sets.",
   },
   {
     id: 3,
     label: "Safety & SMS",
-    description: (
-      <>
-        <p className="mb-4">
-          Localizing Safety Management Systems and fleet-wide safety bulletins to ensure a unified safety culture across your entire fleet.
-        </p>
-      </>
-    )
-  }
+    description:
+      "Localizing Safety Management Systems and fleet-wide safety bulletins to ensure a unified safety culture across your entire fleet.",
+  },
+];
+
+const whyUsCards = [
+  {
+    title: "Individual Account Ownership",
+    description:
+      'You are served by a specific individual, not a rotating queue of employees. This builds a "long-term memory" of your company\u2019s preferred terminology and formatting.',
+  },
+  {
+    title: "24/7 Operational Support",
+    description:
+      'Shipping doesn\u2019t stop. Your dedicated partner is available for "Vessel in Port" emergencies and urgent weekend requests via direct communication lines.',
+  },
+  {
+    title: "Strict Security Protocols",
+    description:
+      "We treat your commercial intelligence with the same privilege as a law firm, utilizing secure transfers and project-specific NDAs for every file.",
+  },
+  {
+    title: "Beyond AI Limitations",
+    description:
+      "Unlike AI, our human-led process understands the critical nuances of maritime law\u2014preserving the technical precision that algorithms frequently overlook.",
+  },
 ];
 
 const languages = [
-  { emoji: "⚓", label: "English & Greek: Global management standards" },
-  { emoji: "🇩🇪", label: "German: Technical engineering and machinery" },
-  { emoji: "🇮🇹", label: "Italian: Shipyard specs and naval architecture" },
-  { emoji: "🇫🇷", label: "French: Mediterranean and West African trade routes" },
-  { emoji: "🇪🇸", label: "Spanish: Port authority and Latin American logistics" }
+  {
+    code: "EN/GR",
+    label: "English & Greek",
+    detail: "Global management standards",
+  },
+  { code: "DE", label: "German", detail: "Technical engineering and machinery" },
+  {
+    code: "IT",
+    label: "Italian",
+    detail: "Shipyard specs and naval architecture",
+  },
+  {
+    code: "FR",
+    label: "French",
+    detail: "Mediterranean and West African trade routes",
+  },
+  {
+    code: "ES",
+    label: "Spanish",
+    detail: "Port authority and Latin American logistics",
+  },
 ];
+
+/* ───────── Compass Rose SVG (background decoration) ───────── */
+
+const CompassRose = () => (
+  <svg
+    viewBox="0 0 200 200"
+    className="absolute right-8 top-1/2 -translate-y-1/2 w-[340px] h-[340px] opacity-[0.06] pointer-events-none hidden lg:block"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="0.8"
+  >
+    <circle cx="100" cy="100" r="90" className="text-amber-300" />
+    <circle cx="100" cy="100" r="70" className="text-amber-300" />
+    <circle cx="100" cy="100" r="4" fill="currentColor" className="text-amber-300" />
+    {/* Cardinal points */}
+    <line x1="100" y1="10" x2="100" y2="190" className="text-amber-300" />
+    <line x1="10" y1="100" x2="190" y2="100" className="text-amber-300" />
+    {/* Diagonal points */}
+    <line x1="36" y1="36" x2="164" y2="164" className="text-amber-300" />
+    <line x1="164" y1="36" x2="36" y2="164" className="text-amber-300" />
+    {/* North arrow */}
+    <polygon points="100,10 94,40 106,40" fill="currentColor" className="text-amber-300" />
+    {/* Outer ring ticks */}
+    {[0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330].map((deg) => {
+      const r1 = 88;
+      const r2 = 94;
+      const rad = (deg * Math.PI) / 180;
+      return (
+        <line
+          key={deg}
+          x1={100 + r1 * Math.sin(rad)}
+          y1={100 - r1 * Math.cos(rad)}
+          x2={100 + r2 * Math.sin(rad)}
+          y2={100 - r2 * Math.cos(rad)}
+          className="text-amber-300"
+        />
+      );
+    })}
+    {/* N / S / E / W labels */}
+    <text x="100" y="24" textAnchor="middle" fontSize="8" fill="currentColor" className="text-amber-300" fontWeight="bold">
+      N
+    </text>
+    <text x="100" y="184" textAnchor="middle" fontSize="8" fill="currentColor" className="text-amber-300" fontWeight="bold">
+      S
+    </text>
+    <text x="182" y="103" textAnchor="middle" fontSize="8" fill="currentColor" className="text-amber-300" fontWeight="bold">
+      E
+    </text>
+    <text x="18" y="103" textAnchor="middle" fontSize="8" fill="currentColor" className="text-amber-300" fontWeight="bold">
+      W
+    </text>
+  </svg>
+);
+
+/* ───────── Animated wave SVG ───────── */
+
+const WaveBackground = () => (
+  <div className="absolute inset-0">
+    {/* Deep navy gradient base */}
+    <div className="absolute inset-0 bg-gradient-to-br from-[#0a1628] via-[#0f2240] to-[#0a1628]" />
+
+    {/* Animated wave layers */}
+    <svg
+      className="absolute bottom-0 left-0 w-full h-48 opacity-10"
+      viewBox="0 0 1440 320"
+      preserveAspectRatio="none"
+    >
+      <motion.path
+        d="M0,224L60,213.3C120,203,240,181,360,186.7C480,192,600,224,720,234.7C840,245,960,235,1080,218.7C1200,203,1320,181,1380,170.7L1440,160L1440,320L1380,320C1320,320,1200,320,1080,320C960,320,840,320,720,320C600,320,480,320,360,320C240,320,120,320,60,320L0,320Z"
+        fill="rgba(191,161,100,0.3)"
+        animate={{ x: [0, -30, 0] }}
+        transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
+      />
+      <motion.path
+        d="M0,256L60,261.3C120,267,240,277,360,272C480,267,600,245,720,240C840,235,960,245,1080,250.7C1200,256,1320,256,1380,256L1440,256L1440,320L1380,320C1320,320,1200,320,1080,320C960,320,840,320,720,320C600,320,480,320,360,320C240,320,120,320,60,320L0,320Z"
+        fill="rgba(191,161,100,0.15)"
+        animate={{ x: [0, 20, 0] }}
+        transition={{ duration: 6, repeat: Infinity, ease: "easeInOut" }}
+      />
+    </svg>
+
+    {/* Brass/gold glow accents */}
+    <div className="absolute top-20 right-1/4 w-72 h-72 rounded-full bg-amber-500/5 blur-[100px]" />
+    <div className="absolute bottom-10 left-10 w-48 h-48 rounded-full bg-amber-600/5 blur-[80px]" />
+
+    {/* Compass rose decoration */}
+    <CompassRose />
+  </div>
+);
+
+/* ───────── Page Component ───────── */
 
 export default function MaritimeTranslationPage() {
   const navItems = [
@@ -66,223 +189,261 @@ export default function MaritimeTranslationPage() {
 
   return (
     <div className="w-full bg-base-100 text-base-content">
-      {/* Hero Section */}
-      <div className="hero-section bg-sl h-full pb-16">
-        <div>
-          <section className="relative w-full overflow-hidden bg-slate-900">
-            <div className="container mx-auto px-4 md:px-8"></div>
-            <Image
-              src="/bg-maritime.jpg"
-              alt="Maritime vessels and operations"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-r from-slate-900 via-slate-900/90 to-transparent"></div>
-            <div className="relative z-10 h-full items-center px-8 lg:px-24">
-              <Header navItems={navItems} />
-              <div className="max-w-xl text-white mt-8">
-                <div>
-                  <h4 className="bg-accent text-accent-content text-xs shadow-lg rounded-3xl inline-block mb-8 px-4 py-2">
-                    Boutique, human-led linguistic support with a dedicated partner for every fleet
-                  </h4>
-                  <h1 className="text-5xl leading-tight font-bold mb-4">
-                    High-Stakes Maritime Translation: Precision for the Global Fleet
-                  </h1>
-                  <p className="text-xl mb-16">
-                    In shipping, a &ldquo;near-miss&rdquo; costs more than just time—it costs operational safety. We provide boutique, human-led linguistic support with a dedicated partner for every fleet.
-                  </p>
-                  <div className="flex flex-col sm:flex-row gap-4">
-                    <button
-                      className="btn btn-lg btn-accent"
-                      onClick={() => window.Beacon("open")}
-                    >
-                      Get a free estimate
-                    </button>
-                    <Link
-                      href="/portfolio"
-                      className="btn btn-lg btn-outline btn-accent"
-                    >
-                      View Portfolio
-                    </Link>
-                  </div>
-                </div>
-              </div>
-              <div className="grid grid-cols-1 gap-8 md:grid-cols-3 my-16 text-white">
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Maritime Subject Matter Experts</h4>
-                  <p>We pair naval linguists with industry-standard glossaries to guarantee absolute terminology consistency from the bridge to the engine room.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Safety-First TEP Workflow</h4>
-                  <p>Our gold-standard Translation, Editing, and Proofreading workflow eliminates the risks of non-compliance.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">A Dedicated Single Point of Contact</h4>
-                  <p>Forget anonymous help-desks. You are assigned a permanent project lead who understands your fleet&apos;s history, terminology, and specific operational needs.</p>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
-
-      {/* About Section */}
-      <div className="container mx-auto">
-        <div className="lg:w-2/3 p-8">
-          <p className="text-2xl mb-2 text-muted-foreground">
-            Precision and Personal Accountability for the Greek Shipping Cluster
-          </p>
-          <h2 className="text-4xl font-bold mb-8">
-            Boutique Agency Excellence
-          </h2>
-          <p className="text-xl mb-4">
-            We specialize in technical and legal maritime translation for shipowners, crewing managers, and maritime law firms. Whether managing dense engineering manuals from German shipyards or complex Italian litigation, we deliver documentation that meets the highest international standards.
-          </p>
-          <p className="text-xl mb-8">
-            At Afterwords, we move beyond the &ldquo;agency model.&rdquo; We operate as a remote extension of your office, assigning a dedicated specialist to your account. This ensures that the person handling your LMAA arbitration today is the same one who understands your fleet&apos;s technical DNA tomorrow.
-          </p>
-        </div>
-      </div>
-
-      {/* Services Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8" id="services">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our specialized maritime services
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Service Portfolio</h2>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 mb-8">
-              {services.map((service) => (
-                <ServiceCard
-                  key={service.id}
-                  label={service.label}
-                  description={service.description}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Why Us Section */}
-      <div className="bg-base-300">
-        <div className="container mx-auto">
-          <div className="p-8" id="why">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Why choose us
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Dedicated Fleet Partnership</h2>
-            <p className="text-xl mb-8 md:w-3/4 lg:w-2/3">
-              Unlike AI, our human-led process understands the critical nuances of maritime law—preserving the technical precision that algorithms frequently overlook.
-            </p>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 mb-8">
-              <ServiceCard
-                label="Individual Account Ownership"
-                description="You are served by a specific individual, not a rotating queue of employees. This builds a &ldquo;long-term memory&rdquo; of your company's preferred terminology and formatting."
-              />
-              <ServiceCard
-                label="24/7 Operational Support"
-                description="Shipping doesn't stop. Your dedicated partner is available for &ldquo;Vessel in Port&rdquo; emergencies and urgent weekend requests via direct communication lines."
-              />
-              <ServiceCard
-                label="Strict Security Protocols"
-                description="We treat your commercial intelligence with the same privilege as a law firm, utilizing secure transfers and project-specific NDAs for every file."
-              />
-              <ServiceCard
-                label="Beyond AI Limitations"
-                description="Unlike AI, our human-led process understands the critical nuances of maritime law—preserving the technical precision that algorithms frequently overlook."
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Specializations Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our expertise
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Deep Specialization in European Maritime Hubs</h2>
-            <p className="text-xl mb-8 lg:w-2/3">
-              We provide end-to-end linguistic solutions for high-impact shipping projects across these core jurisdictions:
-            </p>
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mb-8">
-              {languages.map((lang) => (
-                <LabeledEmoji key={lang.label} emoji={lang.emoji} label={lang.label} />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* CTA Section */}
-      <div className="hero-section h-full pb-16 text-white" style={{ background: 'linear-gradient(to top right, oklch(27% 0.041 260.031), oklch(44% 0.043 257.281), oklch(27% 0.046 192.524))' }}>
-        <div className="container mx-auto">
-          <div className="xl:w-2/3 p-8 pb-0 text-white">
-            <p className="text-2xl text-slate-400 mb-2">
-              Ready to discuss your maritime translation project?
-            </p>
-            <h3 className="text-4xl font-bold mb-8">
-              Your dedicated partner is ready
-            </h3>
-            <p className="text-xl mb-8 md:w-2/3">
-              Whether it&apos;s a 1,000-page technical manual or an urgent arbitration claim, your dedicated partner is ready to deliver excellence.
-            </p>
+      {/* ── Hero ── */}
+      <PageHero
+        navItems={navItems}
+        badge="Boutique, human-led linguistic support with a dedicated partner for every fleet"
+        title="High-Stakes Maritime Translation: Precision for the Global Fleet"
+        subtitle='In shipping, a "near-miss" costs more than just time — it costs operational safety. We provide boutique, human-led linguistic support with a dedicated partner for every fleet.'
+        variant="full"
+        backgroundElement={<WaveBackground />}
+        cta={
+          <div className="flex flex-col sm:flex-row gap-4">
             <button
-              className="btn btn-accent"
+              className="group relative inline-flex items-center gap-2 bg-amber-500 text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-amber-400 transition-all duration-300 hover:shadow-lg hover:shadow-amber-500/20"
               onClick={() => window.Beacon("open")}
             >
-              Contact us →
+              Get a free estimate
+              <svg
+                className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 7l5 5m0 0l-5 5m5-5H6"
+                />
+              </svg>
             </button>
+            <Link
+              href="/portfolio"
+              className="inline-flex items-center gap-2 font-semibold px-8 py-4 rounded-xl border border-amber-500/40 text-amber-300 hover:bg-amber-500/10 transition-all duration-300"
+            >
+              View Portfolio
+            </Link>
           </div>
-        </div>
-      </div>
+        }
+        features={[
+          {
+            title: "Maritime Subject Matter Experts",
+            description:
+              "We pair naval linguists with industry-standard glossaries to guarantee absolute terminology consistency from the bridge to the engine room.",
+          },
+          {
+            title: "Safety-First TEP Workflow",
+            description:
+              "Our gold-standard Translation, Editing, and Proofreading workflow eliminates the risks of non-compliance.",
+          },
+          {
+            title: "A Dedicated Single Point of Contact",
+            description:
+              "Forget anonymous help-desks. You are assigned a permanent project lead who understands your fleet\u2019s history, terminology, and specific operational needs.",
+          },
+        ]}
+      />
 
-      {/* Footer */}
-      <div className="bg-slate-900">
-        <div className="container mx-auto p-8">
-          <Image
-            alt="Afterwords logo"
-            src="/logo.svg"
-            width={200}
-            height={50}
-            className="mb-8 w-1/3 md:w-1/4"
-          />
-          <div className="flex items-center">
-            <h3 className="text-white text-xl mr-4">Find us on social media</h3>
-            <a href="https://www.instagram.com/afterwordstranslations/" className="inline-block mr-4">
-              <Image
-                alt="Instagram logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/insta.svg"
+      {/* ── About Section ── */}
+      <section className="py-20 md:py-28">
+        <div className="container mx-auto px-8">
+          <div className="lg:grid lg:grid-cols-3 gap-16 items-start">
+            <div className="lg:col-span-2">
+              <SectionHeader
+                eyebrow="Precision and Personal Accountability for the Greek Shipping Cluster"
+                title="Boutique Agency"
+                titleItalic="Excellence"
               />
-            </a>
-            <a href="https://www.linkedin.com/company/afterwordstranslations" className="inline-block mr-4">
-              <Image
-                alt="LinkedIn logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/in.png"
-              />
-            </a>
-            <a href="https://www.facebook.com/AfterWordstranslations" className="inline-block mr-4">
-              <Image
-                alt="Facebook logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/fb.png"
-              />
-            </a>
+              <FadeIn delay={0.2}>
+                <p className="text-lg md:text-xl leading-relaxed text-base-content/70 mt-8 mb-4">
+                  We specialize in technical and legal maritime translation for
+                  shipowners, crewing managers, and maritime law firms. Whether
+                  managing dense engineering manuals from German shipyards or
+                  complex Italian litigation, we deliver documentation that meets
+                  the highest international standards.
+                </p>
+              </FadeIn>
+              <FadeIn delay={0.3}>
+                <p className="text-lg md:text-xl leading-relaxed text-base-content/70">
+                  At Afterwords, we move beyond the &ldquo;agency model.&rdquo;
+                  We operate as a remote extension of your office, assigning a
+                  dedicated specialist to your account. This ensures that the
+                  person handling your LMAA arbitration today is the same one who
+                  understands your fleet&apos;s technical DNA tomorrow.
+                </p>
+              </FadeIn>
+            </div>
+
+            {/* Decorative brass compass card */}
+            <FadeIn direction="right" delay={0.3} className="hidden lg:block mt-8">
+              <div className="relative rounded-2xl border border-amber-500/20 bg-gradient-to-br from-slate-50 to-amber-50/50 p-8 shadow-sm">
+                <div className="absolute -top-3 left-6 bg-amber-500 text-slate-900 text-xs font-bold uppercase tracking-wider px-3 py-1 rounded-full">
+                  Est. 2015
+                </div>
+                <div className="flex justify-center mb-4 mt-2">
+                  <svg viewBox="0 0 60 60" className="w-16 h-16 text-amber-600/60" fill="none" stroke="currentColor" strokeWidth="0.8">
+                    <circle cx="30" cy="30" r="28" />
+                    <circle cx="30" cy="30" r="22" />
+                    <line x1="30" y1="4" x2="30" y2="56" />
+                    <line x1="4" y1="30" x2="56" y2="30" />
+                    <polygon points="30,6 28,18 32,18" fill="currentColor" />
+                  </svg>
+                </div>
+                <p className="text-center text-sm text-base-content/60 leading-relaxed">
+                  Your dedicated partner for maritime linguistic excellence across the European shipping cluster.
+                </p>
+              </div>
+            </FadeIn>
           </div>
         </div>
-      </div>
+      </section>
+
+      {/* ── Services Section — Ship's Log Style ── */}
+      <section id="services" className="py-20 md:py-28 bg-gradient-to-b from-slate-50 to-white">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our specialized maritime services"
+            title="Service"
+            titleItalic="Portfolio"
+            description="Each engagement is logged with the same rigour as a ship's operational record."
+          />
+
+          <StaggerContainer className="mt-16 space-y-0" staggerDelay={0.15}>
+            {services.map((service, i) => (
+              <StaggerItem key={service.id}>
+                <div className="group relative flex gap-6 md:gap-8 py-8 border-b border-slate-200 last:border-b-0">
+                  {/* Brass left accent */}
+                  <div className="hidden sm:flex flex-col items-center">
+                    <span className="text-xs font-bold text-amber-700/70 tracking-widest uppercase mb-2">
+                      {String(i + 1).padStart(2, "0")}
+                    </span>
+                    <div className="w-px flex-1 bg-gradient-to-b from-amber-500 to-amber-500/20" />
+                  </div>
+
+                  <div className="flex-1">
+                    <div className="flex items-start gap-4">
+                      {/* Brass dot marker */}
+                      <div className="mt-2 w-2.5 h-2.5 rounded-full bg-amber-500 ring-4 ring-amber-500/10 flex-shrink-0 sm:hidden" />
+                      <div>
+                        <h3 className="text-xl md:text-2xl font-bold text-base-content mb-3 group-hover:text-amber-700 transition-colors duration-300">
+                          {service.label}
+                        </h3>
+                        <p className="text-base-content/70 text-base md:text-lg leading-relaxed max-w-2xl">
+                          {service.description}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* ── Why Us Section — Navy/Brass Cards ── */}
+      <section
+        id="why"
+        className="py-20 md:py-28 relative overflow-hidden"
+        style={{
+          background:
+            "linear-gradient(135deg, #0a1628 0%, #0f2240 50%, #0a1e3a 100%)",
+        }}
+      >
+        {/* Background decoration */}
+        <div className="absolute top-0 right-0 w-96 h-96 rounded-full bg-amber-500/5 blur-[120px]" />
+
+        <div className="container mx-auto px-8 relative z-10">
+          <SectionHeader
+            eyebrow="Why choose us"
+            title="Dedicated Fleet"
+            titleItalic="Partnership"
+            description="Unlike AI, our human-led process understands the critical nuances of maritime law — preserving the technical precision that algorithms frequently overlook."
+            light
+          />
+
+          <StaggerContainer
+            className="grid grid-cols-1 sm:grid-cols-2 gap-6 mt-16"
+            staggerDelay={0.12}
+          >
+            {whyUsCards.map((card) => (
+              <StaggerItem key={card.title}>
+                <div className="group relative h-full rounded-2xl border border-white/10 bg-white/[0.03] backdrop-blur-sm p-8 hover:border-amber-500/30 hover:bg-white/[0.06] transition-all duration-500">
+                  {/* Brass top accent line */}
+                  <div className="absolute top-0 left-8 right-8 h-px bg-gradient-to-r from-transparent via-amber-500/40 to-transparent" />
+
+                  <h3 className="text-lg font-bold text-white mb-3 group-hover:text-amber-300 transition-colors duration-300">
+                    {card.title}
+                  </h3>
+                  <p className="text-white/60 text-sm leading-relaxed">
+                    {card.description}
+                  </p>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* ── Languages Section — Route Map / Ports ── */}
+      <section className="py-20 md:py-28">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our expertise"
+            title="European Maritime"
+            titleItalic="Hubs"
+            description="We provide end-to-end linguistic solutions for high-impact shipping projects across these core jurisdictions:"
+          />
+
+          <div className="mt-16 relative">
+            {/* Connecting dotted line (vertical on mobile, horizontal on desktop) */}
+            <div className="absolute top-0 bottom-0 left-[19px] md:left-0 md:top-1/2 md:right-0 md:bottom-auto md:w-full md:h-px border-l md:border-l-0 md:border-t-2 border-dashed border-amber-500/30 md:-translate-y-1/2 z-0" />
+
+            <StaggerContainer
+              className="relative z-10 grid grid-cols-1 md:grid-cols-5 gap-8 md:gap-4"
+              staggerDelay={0.1}
+            >
+              {languages.map((lang) => (
+                <StaggerItem key={lang.code}>
+                  <div className="flex md:flex-col md:items-center gap-4 md:gap-0 md:text-center group">
+                    {/* Port marker */}
+                    <div className="relative flex-shrink-0">
+                      <div className="w-10 h-10 rounded-full bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center shadow-lg shadow-amber-500/20 group-hover:scale-110 transition-transform duration-300">
+                        <span className="text-[10px] font-bold text-slate-900 tracking-wider">
+                          {lang.code}
+                        </span>
+                      </div>
+                      {/* Pulse ring */}
+                      <div className="absolute inset-0 rounded-full border-2 border-amber-400/30 animate-ping opacity-0 group-hover:opacity-100" />
+                    </div>
+
+                    <div className="md:mt-4">
+                      <h4 className="font-bold text-base-content text-sm md:text-base">
+                        {lang.label}
+                      </h4>
+                      <p className="text-base-content/60 text-sm mt-1">
+                        {lang.detail}
+                      </p>
+                    </div>
+                  </div>
+                </StaggerItem>
+              ))}
+            </StaggerContainer>
+          </div>
+        </div>
+      </section>
+
+      {/* ── CTA ── */}
+      <CTASection
+        eyebrow="Ready to discuss your maritime translation project?"
+        title="Your dedicated partner is ready"
+        description="Whether it's a 1,000-page technical manual or an urgent arbitration claim, your dedicated partner is ready to deliver excellence."
+        buttonText="Contact us"
+      />
+
+      {/* ── Footer ── */}
+      <Footer />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,7 +41,8 @@ const primaryServices = [
         <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
       </svg>
     ),
-    accent: "from-blue-500/10 to-indigo-500/10",
+    borderColor: "border-t-blue-500",
+    iconColor: "text-blue-500",
   },
   {
     label: "Interpreting Services",
@@ -52,7 +53,8 @@ const primaryServices = [
         <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
       </svg>
     ),
-    accent: "from-emerald-500/10 to-teal-500/10",
+    borderColor: "border-t-emerald-500",
+    iconColor: "text-emerald-500",
   },
   {
     label: "Subtitling Services",
@@ -63,17 +65,18 @@ const primaryServices = [
         <path strokeLinecap="round" strokeLinejoin="round" d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z" />
       </svg>
     ),
-    accent: "from-amber-500/10 to-orange-500/10",
+    borderColor: "border-t-amber-500",
+    iconColor: "text-amber-500",
   },
 ];
 
 const industries = [
-  { label: "Pharmaceutical & Life Sciences", href: "/pharmaceutical-translation", description: "Regulatory-compliant translation for submissions, clinical documentation, and patient-facing materials.", span: "md:col-span-2" },
-  { label: "Maritime", href: "/maritime-translation", description: "Technical and legal maritime translation for shipowners, crewing managers, and maritime law firms." },
-  { label: "Academic Books", href: "/academic-translation", description: "Translations that preserve the intellectual rigor and voice of scholarly works." },
-  { label: "Legal & Financial", description: "Accurate translations of contracts, legal proceedings, and financial statements.", span: "md:col-span-2" },
-  { label: "Websites", description: "Engaging and culturally attuned translations to enhance your online presence." },
-  { label: "Agriculture & Agroforestry", description: "Specialized translations bolstered by a PDC at Oregon State University." },
+  { label: "Pharmaceutical & Life Sciences", href: "/pharmaceutical-translation", description: "Regulatory-compliant translation for submissions, clinical documentation, and patient-facing materials.", span: "md:col-span-2", borderColor: "border-l-teal-500" },
+  { label: "Maritime", href: "/maritime-translation", description: "Technical and legal maritime translation for shipowners, crewing managers, and maritime law firms.", borderColor: "border-l-blue-500" },
+  { label: "Academic Books", href: "/academic-translation", description: "Translations that preserve the intellectual rigor and voice of scholarly works.", borderColor: "border-l-amber-500" },
+  { label: "Legal & Financial", description: "Accurate translations of contracts, legal proceedings, and financial statements.", span: "md:col-span-2", borderColor: "border-l-indigo-500" },
+  { label: "Websites", description: "Engaging and culturally attuned translations to enhance your online presence.", borderColor: "border-l-emerald-500" },
+  { label: "Agriculture & Agroforestry", description: "Specialized translations bolstered by a PDC at Oregon State University.", borderColor: "border-l-orange-500" },
 ];
 
 export default function Home() {
@@ -87,10 +90,10 @@ export default function Home() {
   return (
     <div className="w-full bg-base-100 text-base-content">
       {/* ===== HERO ===== */}
-      <section className="relative w-full overflow-hidden min-h-[90vh] flex flex-col">
+      <section className="relative w-full overflow-hidden min-h-[100vh] flex flex-col">
         {/* Gradient mesh background */}
         <div className="absolute inset-0">
-          <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-primary to-slate-900" />
+          <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900" />
           <div className="absolute top-0 right-1/4 w-[600px] h-[600px] rounded-full bg-warm/8 blur-[150px]" />
           <div className="absolute bottom-0 left-1/3 w-[400px] h-[400px] rounded-full bg-secondary/20 blur-[120px]" />
           <div className="absolute top-1/3 right-0 w-[300px] h-[300px] rounded-full bg-warm/5 blur-[100px]" />
@@ -100,108 +103,104 @@ export default function Home() {
           <Header navItems={navItems} />
 
           <div className="flex-1 flex items-center">
-            <div className="max-w-3xl py-16">
-              <motion.span
-                className="inline-block text-xs font-semibold uppercase tracking-[0.15em] px-4 py-2 rounded-full bg-warm/20 text-warm border border-warm/30 mb-8"
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
-              >
-                A boutique Greek agency with over 10 years of specialized experience
-              </motion.span>
-
-              <TextReveal
-                text="Precision in every word."
-                className="font-[family-name:var(--font-display)] text-5xl md:text-6xl lg:text-7xl leading-[1.1] font-bold mb-8 text-white"
-                delay={0.2}
-              />
-
-              <motion.p
-                className="text-lg md:text-xl text-white/70 mb-10 max-w-xl leading-relaxed"
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.8 }}
-              >
-                Bridging the gap between the Greek market and the global stage. We provide the linguistic precision and cultural nuance your business needs to expand without borders.
-              </motion.p>
-
-              <motion.div
-                className="flex flex-col sm:flex-row gap-4"
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 1 }}
-              >
-                <button
-                  className="group inline-flex items-center gap-2 bg-warm text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-warm-dark hover:text-white transition-all duration-300 hover:shadow-lg hover:shadow-warm/20 cursor-pointer"
-                  onClick={() => window.Beacon("open")}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-20 w-full py-16 items-center">
+              {/* Left — headline */}
+              <div>
+                <motion.span
+                  className="inline-block text-xs font-semibold uppercase tracking-[0.15em] px-4 py-2 rounded-full bg-warm/20 text-warm border border-warm/30 mb-8"
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.5 }}
                 >
-                  Get a free estimate
-                  <svg className="w-4 h-4 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                  </svg>
-                </button>
-                <Link
-                  href="/portfolio"
-                  className="inline-flex items-center gap-2 border border-white/20 text-white font-semibold px-8 py-4 rounded-xl hover:bg-white/10 transition-all duration-300"
+                  Est. 2015
+                </motion.span>
+
+                <TextReveal
+                  text="Precision in every word."
+                  className="font-[family-name:var(--font-display)] text-5xl md:text-6xl lg:text-7xl xl:text-8xl leading-[1.05] font-bold text-white"
+                  delay={0.2}
+                />
+              </div>
+
+              {/* Right — description, CTAs, features */}
+              <div className="flex flex-col justify-center">
+                <motion.p
+                  className="text-lg md:text-xl text-white/70 mb-8 leading-relaxed"
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.6, delay: 0.8 }}
                 >
-                  View Portfolio
-                </Link>
-              </motion.div>
+                  A boutique Greek translation agency bridging the gap between the Greek market and the global stage. We provide the linguistic precision and cultural nuance your business needs to expand without borders.
+                </motion.p>
+
+                <motion.div
+                  className="flex flex-col sm:flex-row gap-4 mb-12"
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.6, delay: 1 }}
+                >
+                  <button
+                    className="group inline-flex items-center gap-2 bg-warm text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-warm-dark hover:text-white transition-all duration-300 hover:shadow-lg hover:shadow-warm/20 cursor-pointer"
+                    onClick={() => window.Beacon("open")}
+                  >
+                    Get a free estimate
+                    <svg className="w-4 h-4 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                    </svg>
+                  </button>
+                  <Link
+                    href="/portfolio"
+                    className="inline-flex items-center gap-2 border border-white/20 text-white font-semibold px-8 py-4 rounded-xl hover:bg-white/10 transition-all duration-300"
+                  >
+                    View Portfolio
+                  </Link>
+                </motion.div>
+
+                {/* Feature pills — stacked with left border */}
+                <motion.div
+                  className="space-y-4"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ duration: 0.6, delay: 1.2 }}
+                >
+                  {[
+                    { title: "Quality", desc: "2-step review by a native speaker and a subject matter expert." },
+                    { title: "Speed", desc: "Standard turnaround in 48 hours. Rush delivery available." },
+                    { title: "Consistency", desc: "Translation memory and terminology management ensure uniform language." },
+                  ].map((f) => (
+                    <div key={f.title} className="border-l-2 border-warm/40 pl-4">
+                      <h4 className="text-sm font-semibold uppercase tracking-wider text-warm mb-1">{f.title}</h4>
+                      <p className="text-white/50 text-sm leading-relaxed">{f.desc}</p>
+                    </div>
+                  ))}
+                </motion.div>
+              </div>
             </div>
           </div>
-
-          {/* Feature pills */}
-          <motion.div
-            className="grid grid-cols-1 gap-4 md:grid-cols-3 pb-12 pt-8 border-t border-white/10"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6, delay: 1.2 }}
-          >
-            {[
-              { title: "Quality", desc: "Every document undergoes a 2-step review by a native speaker and a subject matter expert." },
-              { title: "Speed", desc: "Standard turnaround in 48 hours; Rush delivery available." },
-              { title: "Consistency", desc: "Translation memory and terminology management ensure uniform language." },
-            ].map((f) => (
-              <div key={f.title} className="group">
-                <h4 className="text-sm font-semibold uppercase tracking-wider text-warm mb-2">{f.title}</h4>
-                <p className="text-white/50 text-sm leading-relaxed">{f.desc}</p>
-              </div>
-            ))}
-          </motion.div>
         </div>
       </section>
 
       {/* ===== ABOUT ===== */}
       <section id="about" className="py-24 md:py-32">
         <div className="container mx-auto px-8">
-          <div className="grid grid-cols-1 lg:grid-cols-5 gap-16 items-start">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             {/* Left column */}
-            <div className="lg:col-span-3">
+            <div>
               <SectionHeader
                 eyebrow="About us"
                 title="Translation is more than"
                 titleItalic="just a document."
                 description="We pride ourselves on delivering tailored language solutions that empower our clients to communicate effectively, reach broader audiences, and achieve their goals with confidence."
               />
-              <FadeIn delay={0.3}>
-                <div className="mt-8 inline-flex items-center gap-3 px-5 py-3 rounded-xl bg-base-200 border border-base-300">
-                  <Image
-                    alt="SDL Trados Studio"
-                    width={120}
-                    height={30}
-                    src="/trados.png"
-                  />
-                </div>
-              </FadeIn>
             </div>
 
-            {/* Right column — floating flags */}
-            <div className="lg:col-span-2 relative min-h-[300px]">
-              <StaggerContainer className="flex flex-wrap gap-4 justify-center lg:justify-end items-center">
+            {/* Right column — language flags */}
+            <div>
+              <StaggerContainer className="grid grid-cols-4 gap-3">
                 {languages.map((lang) => (
                   <StaggerItem key={lang.label}>
-                    <div className="group flex flex-col items-center gap-1 p-3 rounded-xl hover:bg-base-200 transition-colors duration-200 cursor-default">
-                      <span className={`${lang.size} group-hover:scale-110 transition-transform duration-300`}>
+                    <div className="group flex flex-col items-center gap-1.5 p-3 rounded-xl hover:bg-base-200 transition-colors duration-200 cursor-default">
+                      <span className="text-3xl group-hover:scale-110 transition-transform duration-300">
                         {lang.emoji}
                       </span>
                       <span className="text-xs font-medium text-base-content/50">{lang.label}</span>
@@ -226,37 +225,32 @@ export default function Home() {
             description="From certified legal documents to live interpreting and cinematic subtitling — we deliver precision across every medium."
           />
 
-          {/* Primary services — full-width alternating blocks */}
-          <div className="mt-16 space-y-6">
-            <StaggerContainer staggerDelay={0.15} className="space-y-6">
-              {primaryServices.map((service, i) => (
-                <StaggerItem key={service.label}>
-                  <Link href={service.href} className="block group">
-                    <div className={`relative overflow-hidden rounded-2xl border border-base-300 p-8 md:p-10 hover:shadow-xl hover:border-warm/30 transition-all duration-500 bg-gradient-to-br ${service.accent}`}>
-                      <div className={`flex flex-col md:flex-row gap-6 items-start ${i % 2 === 1 ? "md:flex-row-reverse" : ""}`}>
-                        <div className="shrink-0 w-16 h-16 rounded-2xl bg-base-100 border border-base-300 flex items-center justify-center text-warm-dark group-hover:scale-110 transition-transform duration-300">
-                          {service.icon}
-                        </div>
-                        <div className="flex-1">
-                          <h3 className="font-[family-name:var(--font-display)] text-2xl md:text-3xl font-bold mb-3 text-base-content group-hover:text-warm-dark transition-colors duration-300">
-                            {service.label}
-                          </h3>
-                          <p className="text-base-content/60 text-lg leading-relaxed max-w-2xl">
-                            {service.description}
-                          </p>
-                        </div>
-                        <div className="shrink-0 self-center">
-                          <svg className="w-6 h-6 text-base-content/30 group-hover:text-warm-dark group-hover:translate-x-1 transition-all duration-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                          </svg>
-                        </div>
-                      </div>
+          {/* Primary services — 3-column vertical cards */}
+          <StaggerContainer className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-16">
+            {primaryServices.map((service) => (
+              <StaggerItem key={service.label}>
+                <Link href={service.href} className="block group h-full">
+                  <div className={`card-surface h-full flex flex-col rounded-2xl border border-base-300 border-t-4 ${service.borderColor} p-8 hover:shadow-lg hover:-translate-y-1 transition-all duration-300`}>
+                    <div className={`w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center ${service.iconColor} mb-6 group-hover:scale-110 transition-transform duration-300`}>
+                      {service.icon}
                     </div>
-                  </Link>
-                </StaggerItem>
-              ))}
-            </StaggerContainer>
-          </div>
+                    <h3 className="font-[family-name:var(--font-display)] text-2xl font-bold mb-3 text-base-content group-hover:text-warm-dark transition-colors duration-300">
+                      {service.label}
+                    </h3>
+                    <p className="text-base-content/60 text-base leading-relaxed flex-1">
+                      {service.description}
+                    </p>
+                    <div className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-warm-dark">
+                      Learn more
+                      <svg className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                      </svg>
+                    </div>
+                  </div>
+                </Link>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
         </div>
       </section>
 
@@ -270,31 +264,34 @@ export default function Home() {
           />
 
           <StaggerContainer className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-16">
-            {industries.map((ind) => (
-              <StaggerItem key={ind.label} className={ind.span || ""}>
-                {ind.href ? (
-                  <Link href={ind.href} className="block h-full group">
-                    <div className="h-full p-6 rounded-2xl border border-base-300 bg-base-100 hover:shadow-lg hover:border-warm/30 transition-all duration-300">
-                      <h3 className="font-semibold text-lg mb-2 text-base-content group-hover:text-warm-dark transition-colors duration-300">
-                        {ind.label}
-                      </h3>
+            {industries.map((ind) => {
+              const cardClasses = `card-surface h-full p-6 rounded-2xl border border-base-300 border-l-4 ${ind.borderColor} hover:shadow-lg transition-all duration-300`;
+              return (
+                <StaggerItem key={ind.label} className={ind.span || ""}>
+                  {ind.href ? (
+                    <Link href={ind.href} className="block h-full group">
+                      <div className={cardClasses}>
+                        <h3 className="font-semibold text-lg mb-2 text-base-content group-hover:text-warm-dark transition-colors duration-300">
+                          {ind.label}
+                        </h3>
+                        <p className="text-sm text-base-content/60 leading-relaxed">{ind.description}</p>
+                        <span className="inline-flex items-center gap-1 mt-4 text-sm font-medium text-warm-dark opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                          Learn more
+                          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                          </svg>
+                        </span>
+                      </div>
+                    </Link>
+                  ) : (
+                    <div className={cardClasses}>
+                      <h3 className="font-semibold text-lg mb-2 text-base-content">{ind.label}</h3>
                       <p className="text-sm text-base-content/60 leading-relaxed">{ind.description}</p>
-                      <span className="inline-flex items-center gap-1 mt-4 text-sm font-medium text-warm-dark opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                        Learn more
-                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                        </svg>
-                      </span>
                     </div>
-                  </Link>
-                ) : (
-                  <div className="h-full p-6 rounded-2xl border border-base-300 bg-base-100">
-                    <h3 className="font-semibold text-lg mb-2 text-base-content">{ind.label}</h3>
-                    <p className="text-sm text-base-content/60 leading-relaxed">{ind.description}</p>
-                  </div>
-                )}
-              </StaggerItem>
-            ))}
+                  )}
+                </StaggerItem>
+              );
+            })}
           </StaggerContainer>
 
           <FadeIn delay={0.3}>
@@ -320,7 +317,7 @@ export default function Home() {
             description="Our seasoned translators bring together diverse expertise to meet a wide range of translation and interpretation needs."
           />
 
-          <div className="mt-16 max-w-3xl space-y-0">
+          <div className="mt-16 grid grid-cols-1 md:grid-cols-3 gap-6">
             <Translator
               fullName="Aggeliki Gkika"
               imageSrc="/agg_ai.png"
@@ -358,9 +355,9 @@ export default function Home() {
       {/* ===== CTA ===== */}
       <CTASection
         eyebrow="Ready to get started?"
-        title="Feel free to contact us!"
-        description="Do you want to translate your new book or find interpreters for your big conference or event? Or do you have another question?"
-        buttonText="Contact us"
+        title="Let's bring your words to the world."
+        description="Whether you need a book translated, interpreters for a conference, or certified documents for a deadline — we're here to help."
+        buttonText="Get in touch"
       />
 
       {/* ===== FOOTER ===== */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,17 @@
 "use client";
-import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { ServiceCard } from "~/components/Services";
-import LabeledEmoji from "~/components/LabeledEmoji";
-import Translator from "~/components/Translator";
+import { motion } from "framer-motion";
+import { Header } from "~/components/Header";
 import { DecadeSection } from "~/components/DecadeSection";
 import { TestimonialsSection } from "~/components/TestimonialsSection";
-import { Header } from "~/components/Header";
+import { CTASection } from "~/components/CTASection";
+import { Footer } from "~/components/Footer";
+import { SectionHeader } from "~/components/SectionHeader";
+import { FadeIn } from "~/components/animations/FadeIn";
+import { StaggerContainer, StaggerItem } from "~/components/animations/StaggerContainer";
+import { TextReveal } from "~/components/animations/TextReveal";
+import Translator from "~/components/Translator";
 
 declare global {
   interface Window {
@@ -16,329 +20,351 @@ declare global {
   }
 }
 
+const languages = [
+  { emoji: "\u{1F1EC}\u{1F1F7}", label: "Greek", size: "text-5xl" },
+  { emoji: "\u{1F1E9}\u{1F1EA}", label: "German", size: "text-4xl" },
+  { emoji: "\u{1F1EB}\u{1F1F7}", label: "French", size: "text-4xl" },
+  { emoji: "\u{1F1EA}\u{1F1F8}", label: "Spanish", size: "text-3xl" },
+  { emoji: "\u{1F1EE}\u{1F1F9}", label: "Italian", size: "text-3xl" },
+  { emoji: "\u{1F1F8}\u{1F1EA}", label: "Swedish", size: "text-2xl" },
+  { emoji: "\u{1F1F5}\u{1F1F9}", label: "Portuguese", size: "text-2xl" },
+  { emoji: "\u{1F1EB}\u{1F1EE}", label: "Finnish", size: "text-2xl" },
+];
+
+const primaryServices = [
+  {
+    label: "Certified Translations",
+    href: "/certified-translations",
+    description: "Translation of academic and public documents for submission to various authorities.",
+    icon: (
+      <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+      </svg>
+    ),
+    accent: "from-blue-500/10 to-indigo-500/10",
+  },
+  {
+    label: "Interpreting Services",
+    href: "/interpreting",
+    description: "Professional interpreting services to ensure seamless communication in any setting.",
+    icon: (
+      <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+      </svg>
+    ),
+    accent: "from-emerald-500/10 to-teal-500/10",
+  },
+  {
+    label: "Subtitling Services",
+    href: "/audiovisual-translation",
+    description: "From TV series to feature films and entire film festivals, we ensure the narrative remains sharp in every frame.",
+    icon: (
+      <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z" />
+      </svg>
+    ),
+    accent: "from-amber-500/10 to-orange-500/10",
+  },
+];
+
+const industries = [
+  { label: "Pharmaceutical & Life Sciences", href: "/pharmaceutical-translation", description: "Regulatory-compliant translation for submissions, clinical documentation, and patient-facing materials.", span: "md:col-span-2" },
+  { label: "Maritime", href: "/maritime-translation", description: "Technical and legal maritime translation for shipowners, crewing managers, and maritime law firms." },
+  { label: "Academic Books", href: "/academic-translation", description: "Translations that preserve the intellectual rigor and voice of scholarly works." },
+  { label: "Legal & Financial", description: "Accurate translations of contracts, legal proceedings, and financial statements.", span: "md:col-span-2" },
+  { label: "Websites", description: "Engaging and culturally attuned translations to enhance your online presence." },
+  { label: "Agriculture & Agroforestry", description: "Specialized translations bolstered by a PDC at Oregon State University." },
+];
+
 export default function Home() {
   const navItems = [
     { label: "About us", href: "#about" },
     { label: "Our services", href: "#services" },
     { label: "Our team", href: "#team" },
+    { label: "Blog", href: "/blog" },
   ];
 
   return (
     <div className="w-full bg-base-100 text-base-content">
-      {/* Hero Section - Untouched */}
-      <div className="hero-section bg-sl h-full pb-16">
-        <div>
-
-          <section className="relative w-full overflow-hidden bg-slate-900">
-            <Image
-              src="/bg.jpg"
-              alt="Professional signing document"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-r from-slate-900 via-slate-900/90 to-transparent"></div>
-            <div className="relative z-10 h-full items-center px-8 lg:px-24">
-              <Header navItems={navItems} />
-              <div className="max-w-xl text-white">
-                <div>
-                  <h4 className="bg-accent text-accent-content text-xs shadow-lg rounded-3xl inline-block mb-8 px-4 py-2">
-                    A boutique Greek agency with over 10 years of specialized experience.
-                  </h4>
-
-                  <h1 className="text-5xl leading-tight font-bold mb-4">
-                    {" "}
-                    Precision in every word.
-                  </h1>
-                  <p className="text-xl mb-16">
-                    Bridging the gap between the Greek market and the global stage. We provide the linguistic precision and cultural nuance your business needs to expand without borders.
-                  </p>
-                  <div className="flex flex-col sm:flex-row gap-4">
-                    <button
-                      className="btn btn-lg btn-accent"
-                      onClick={() => window.Beacon("open")}
-                    >
-                      Get a free estimate
-                    </button>
-                    <Link
-                      href="/portfolio"
-                      className="btn btn-lg btn-outline btn-accent"
-                    >
-                      View Portfolio
-                    </Link>
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 gap-8 md:grid-cols-3 my-16 text-white">
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Quality</h4>
-                  <p>Every document undergoes a 2-step review by a native speaker and a subject matter expert.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Speed</h4>
-                  <p>Standard turnaround in 48 hours; Rush delivery available.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Consistency</h4>
-                  <p>Translation memory and terminology management ensure uniform language.</p>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div >
-
-      </div >
-
-      {/* About Section - Theme Applied */}
-      < div className="container mx-auto" >
-        <div id="about" className="lg:w-2/3 p-8">
-          <p className="text-2xl mb-2 text-muted-foreground">
-            About us
-          </p>
-          <h2 className="text-4xl font-bold mb-8">
-            Translation is more than <i className="font-normal">just</i> a
-            document.
-          </h2>
-
-          <p className="text-xl mb-4">
-            We pride ourselves on delivering tailored language solutions that
-            empower our clients to communicate effectively, reach broader
-            audiences, and achieve their goals with confidence.
-          </p>
-
-          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-            <LabeledEmoji emoji="🇬🇷" label="Greek" />
-            <LabeledEmoji emoji="🇩🇪" label="German" />
-            <LabeledEmoji emoji="🇫🇷" label="French" />
-            <LabeledEmoji emoji="🇪🇸" label="Spanish" />
-            <LabeledEmoji emoji="🇮🇹" label="Italian" />
-            <LabeledEmoji emoji="🇸🇪" label="Swedish" />
-            <LabeledEmoji emoji="🇵🇹" label="Portuguese" />
-            <LabeledEmoji emoji="🇫🇮" label="Finnish" />
-          </div>
-          <Image
-            alt="I work with SDL Trados Studio"
-            width={200}
-            height={50}
-            src="/trados.png"
-            className="sm:w-2/3 lg:w-2/5"
-          />
+      {/* ===== HERO ===== */}
+      <section className="relative w-full overflow-hidden min-h-[90vh] flex flex-col">
+        {/* Gradient mesh background */}
+        <div className="absolute inset-0">
+          <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-primary to-slate-900" />
+          <div className="absolute top-0 right-1/4 w-[600px] h-[600px] rounded-full bg-warm/8 blur-[150px]" />
+          <div className="absolute bottom-0 left-1/3 w-[400px] h-[400px] rounded-full bg-secondary/20 blur-[120px]" />
+          <div className="absolute top-1/3 right-0 w-[300px] h-[300px] rounded-full bg-warm/5 blur-[100px]" />
         </div>
-      </div >
 
+        <div className="relative z-10 px-8 lg:px-24 flex-1 flex flex-col">
+          <Header navItems={navItems} />
+
+          <div className="flex-1 flex items-center">
+            <div className="max-w-3xl py-16">
+              <motion.span
+                className="inline-block text-xs font-semibold uppercase tracking-[0.15em] px-4 py-2 rounded-full bg-warm/20 text-warm border border-warm/30 mb-8"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5 }}
+              >
+                A boutique Greek agency with over 10 years of specialized experience
+              </motion.span>
+
+              <TextReveal
+                text="Precision in every word."
+                className="font-[family-name:var(--font-display)] text-5xl md:text-6xl lg:text-7xl leading-[1.1] font-bold mb-8 text-white"
+                delay={0.2}
+              />
+
+              <motion.p
+                className="text-lg md:text-xl text-white/70 mb-10 max-w-xl leading-relaxed"
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.8 }}
+              >
+                Bridging the gap between the Greek market and the global stage. We provide the linguistic precision and cultural nuance your business needs to expand without borders.
+              </motion.p>
+
+              <motion.div
+                className="flex flex-col sm:flex-row gap-4"
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 1 }}
+              >
+                <button
+                  className="group inline-flex items-center gap-2 bg-warm text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-warm-dark hover:text-white transition-all duration-300 hover:shadow-lg hover:shadow-warm/20 cursor-pointer"
+                  onClick={() => window.Beacon("open")}
+                >
+                  Get a free estimate
+                  <svg className="w-4 h-4 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                  </svg>
+                </button>
+                <Link
+                  href="/portfolio"
+                  className="inline-flex items-center gap-2 border border-white/20 text-white font-semibold px-8 py-4 rounded-xl hover:bg-white/10 transition-all duration-300"
+                >
+                  View Portfolio
+                </Link>
+              </motion.div>
+            </div>
+          </div>
+
+          {/* Feature pills */}
+          <motion.div
+            className="grid grid-cols-1 gap-4 md:grid-cols-3 pb-12 pt-8 border-t border-white/10"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.6, delay: 1.2 }}
+          >
+            {[
+              { title: "Quality", desc: "Every document undergoes a 2-step review by a native speaker and a subject matter expert." },
+              { title: "Speed", desc: "Standard turnaround in 48 hours; Rush delivery available." },
+              { title: "Consistency", desc: "Translation memory and terminology management ensure uniform language." },
+            ].map((f) => (
+              <div key={f.title} className="group">
+                <h4 className="text-sm font-semibold uppercase tracking-wider text-warm mb-2">{f.title}</h4>
+                <p className="text-white/50 text-sm leading-relaxed">{f.desc}</p>
+              </div>
+            ))}
+          </motion.div>
+        </div>
+      </section>
+
+      {/* ===== ABOUT ===== */}
+      <section id="about" className="py-24 md:py-32">
+        <div className="container mx-auto px-8">
+          <div className="grid grid-cols-1 lg:grid-cols-5 gap-16 items-start">
+            {/* Left column */}
+            <div className="lg:col-span-3">
+              <SectionHeader
+                eyebrow="About us"
+                title="Translation is more than"
+                titleItalic="just a document."
+                description="We pride ourselves on delivering tailored language solutions that empower our clients to communicate effectively, reach broader audiences, and achieve their goals with confidence."
+              />
+              <FadeIn delay={0.3}>
+                <div className="mt-8 inline-flex items-center gap-3 px-5 py-3 rounded-xl bg-base-200 border border-base-300">
+                  <Image
+                    alt="SDL Trados Studio"
+                    width={120}
+                    height={30}
+                    src="/trados.png"
+                  />
+                </div>
+              </FadeIn>
+            </div>
+
+            {/* Right column — floating flags */}
+            <div className="lg:col-span-2 relative min-h-[300px]">
+              <StaggerContainer className="flex flex-wrap gap-4 justify-center lg:justify-end items-center">
+                {languages.map((lang) => (
+                  <StaggerItem key={lang.label}>
+                    <div className="group flex flex-col items-center gap-1 p-3 rounded-xl hover:bg-base-200 transition-colors duration-200 cursor-default">
+                      <span className={`${lang.size} group-hover:scale-110 transition-transform duration-300`}>
+                        {lang.emoji}
+                      </span>
+                      <span className="text-xs font-medium text-base-content/50">{lang.label}</span>
+                    </div>
+                  </StaggerItem>
+                ))}
+              </StaggerContainer>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ===== DECADE STATS ===== */}
       <DecadeSection />
 
-      {/* Services Section - Theme Applied */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8" id="services">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our services
-            </p>
-            <h2 className="text-4xl font-bold mb-8">How we can help you</h2>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-3 mb-8">
-              <ServiceCard
-                label="Certified Translations"
-                learnMore="/certified-translations"
-                description={
-                  <>
-                    Translation of academic and public documents for submission
-                    to various authorities.
-                  </>
-                }
-              />
-              <ServiceCard
-                label="Interpreting Services"
-                learnMore="/interpreting"
-                description={
-                  <>
-                    We provide professional interpreting services to ensure
-                    seamless communication in any setting.
-                  </>
-                }
-              />
-              <ServiceCard
-                label="Subtitling Services"
-                learnMore="/audiovisual-translation"
-                description={
-                  <>
-                    From TV series to feature films and entire film festivals, we
-                    ensure the narrative remains sharp in every frame.
-                  </>
-                }
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div className="bg-base-300">
-        <div className="container mx-auto">
-
-          {/* Industries Section - Theme Applied */}
-          <div className="p-8">
-            <h3 className="text-2xl font-bold mt-8 mb-4">Industries we serve</h3>
-
-            <p className="text-xl mb-8 md:w-3/4 lg:w-2/3">
-              We provide specialized translation services designed to meet the
-              unique needs of businesses, organizations, and individuals. Our
-              expertise spans multiple areas.
-            </p>
-
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 mb-8">
-              <ServiceCard
-                label="Pharmaceutical & Life Sciences"
-                learnMore="/pharmaceutical-translation"
-                description="Regulatory-compliant translation for submissions, clinical documentation, pharmacovigilance, and patient-facing materials."
-              />
-              <ServiceCard
-                label="Maritime"
-                description="Technical and legal maritime translation for shipowners, crewing managers, and maritime law firms."
-                learnMore="/maritime-translation"
-              />
-              <ServiceCard
-                label="Academic Books"
-                description="High-quality translations that preserve the intellectual rigor, nuance, and voice of scholarly works for academic publication."
-                learnMore="/academic-translation"
-              />
-            </div>
-
-            <h4 className="text-sm text-muted-foreground mb-6 uppercase tracking-wider font-semibold">We also specialize in</h4>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 mb-8">
-
-              <ServiceCard
-                label="Legal & Financial"
-                description="Accurate and dependable translations of contracts, legal proceedings, financial statements, and related documents."
-              />
-              <ServiceCard
-                description="Engaging and culturally attuned translations to enhance your online presence and global reach."
-                label="Websites"
-              />
-              <ServiceCard
-                description="Specialized translations rooted in practical expertise, bolstered by a Permaculture Design Certificate (PDC) at Oregon State University."
-                label="Agriculture & Agroforestry"
-              />
-            </div>
-
-            <button
-              className="btn btn-primary"
-              onClick={() => window.Beacon("open")}
-            >
-              Tell us about your industry →
-            </button>
-          </div>
-        </div>
-      </div>
-
-
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          {/* Team Section - Theme Applied */}
-          <div id="team" className="p-8">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our team
-            </p>
-            <h2 className="text-4xl font-bold mb-8">You are in good hands</h2>
-            <p className="text-xl mb-8 lg:w-2/3 ">
-              Our seasoned translators bring together diverse expertise to meet a
-              wide range of translation and interpretation needs.
-            </p>
-            <div className="mb-16 text-xl lg:w-3/4 ">
-              <Translator
-                fullName="Aggeliki Gkika"
-                imageSrc="/agg_ai.png"
-                shortName="Aggeliki"
-                href="https://www.linkedin.com/in/agkika/"
-                description="Aggeliki specializes in pharmaceutical, medical, clinical and patent translations, ensuring accuracy and professionalism in highly specialized fields."
-              />
-              <Translator
-                fullName="Chrysanthi Partsanaki"
-                imageSrc="/chrysa_ai.png"
-                shortName="Chrysanthi"
-                href="https://www.linkedin.com/in/cpartsanaki/"
-                description="Chrysanthi delivers precision in academic, financial, legal, and maritime translation, complemented by professional Greek/English and Greek/Spanish interpretation services."
-              />
-              <Translator
-                fullName="Anna Maria Chatzistylianou"
-                imageSrc="/am_ai.png"
-                shortName="Anna Maria"
-                href="https://www.linkedin.com/in/amchatzistylianou/"
-                description="Anna Maria is your go-to specialist for maritime and legal translation, delivering linguistic precision with deep industry knowledge."
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Client Testimonials Section - Hero gradient background with glass-morphism cards */}
-      <div className="hero-section h-full pb-16 text-white" style={{ background: 'linear-gradient(to top right, oklch(27% 0.041 260.031), oklch(44% 0.043 257.281), oklch(27% 0.046 192.524))' }}>
-        <TestimonialsSection />
-        <div className="container mx-auto">
-          <div className="xl:w-2/3 p-8 pb-0 text-white">
-            <p className="text-2xl text-slate-400 mb-2">
-              Need a certified translation today??{" "}
-            </p>
-            <h3 className="text-4xl font-bold mb-8">
-              Feel free to contact us!
-            </h3>
-            <p className="text-xl mb-8 md:w-2/3">
-              What is your next big web project?
-            </p>
-            <p className="text-xl mb-8 md:w-2/3">
-              Do you want to translate your new book or find interpreters for
-              your big conference or event? Or do you have another question?{" "}
-            </p>
-            <button
-              className="btn btn-accent"
-              onClick={() => window.Beacon("open")}
-            >
-              Contact us →
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Footer - Untouched */}
-      <div className="bg-slate-900">
-        <div className="container mx-auto p-8">
-          <Image
-            alt="Afterwords logo"
-            src="/logo.svg"
-            width={200}
-            height={50}
-            className="mb-8 w-1/3 md:w-1/5"
+      {/* ===== SERVICES ===== */}
+      <section id="services" className="py-24 md:py-32">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our services"
+            title="How we can help you"
+            description="From certified legal documents to live interpreting and cinematic subtitling — we deliver precision across every medium."
           />
-          <div className="flex items-center">
-            <h3 className="text-white text-xl mr-4">Find us on social media</h3>
-            <a href="https://www.instagram.com/afterwordstranslations/" className="inline-block mr-4">
-              <Image
-                alt="Instagram logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/insta.svg"
-              />
-            </a>
-            <a href="https://www.linkedin.com/company/afterwordstranslations/" className="inline-block mr-4">
-              <Image
-                alt="LinkedIn logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/in.png"
-              />
-            </a>
-            <a href="https://www.facebook.com/AfterWordstranslations" className="inline-block mr-4">
-              <Image
-                alt="Facebook logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/fb.png"
-              />
-            </a>
+
+          {/* Primary services — full-width alternating blocks */}
+          <div className="mt-16 space-y-6">
+            <StaggerContainer staggerDelay={0.15} className="space-y-6">
+              {primaryServices.map((service, i) => (
+                <StaggerItem key={service.label}>
+                  <Link href={service.href} className="block group">
+                    <div className={`relative overflow-hidden rounded-2xl border border-base-300 p-8 md:p-10 hover:shadow-xl hover:border-warm/30 transition-all duration-500 bg-gradient-to-br ${service.accent}`}>
+                      <div className={`flex flex-col md:flex-row gap-6 items-start ${i % 2 === 1 ? "md:flex-row-reverse" : ""}`}>
+                        <div className="shrink-0 w-16 h-16 rounded-2xl bg-base-100 border border-base-300 flex items-center justify-center text-warm-dark group-hover:scale-110 transition-transform duration-300">
+                          {service.icon}
+                        </div>
+                        <div className="flex-1">
+                          <h3 className="font-[family-name:var(--font-display)] text-2xl md:text-3xl font-bold mb-3 text-base-content group-hover:text-warm-dark transition-colors duration-300">
+                            {service.label}
+                          </h3>
+                          <p className="text-base-content/60 text-lg leading-relaxed max-w-2xl">
+                            {service.description}
+                          </p>
+                        </div>
+                        <div className="shrink-0 self-center">
+                          <svg className="w-6 h-6 text-base-content/30 group-hover:text-warm-dark group-hover:translate-x-1 transition-all duration-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                </StaggerItem>
+              ))}
+            </StaggerContainer>
           </div>
         </div>
-      </div>
-    </div >
+      </section>
+
+      {/* ===== INDUSTRIES ===== */}
+      <section className="py-24 md:py-32 bg-base-200">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Industries we serve"
+            title="Specialized expertise across sectors"
+            description="We provide specialized translation services designed to meet the unique needs of businesses, organizations, and individuals."
+          />
+
+          <StaggerContainer className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-16">
+            {industries.map((ind) => (
+              <StaggerItem key={ind.label} className={ind.span || ""}>
+                {ind.href ? (
+                  <Link href={ind.href} className="block h-full group">
+                    <div className="h-full p-6 rounded-2xl border border-base-300 bg-base-100 hover:shadow-lg hover:border-warm/30 transition-all duration-300">
+                      <h3 className="font-semibold text-lg mb-2 text-base-content group-hover:text-warm-dark transition-colors duration-300">
+                        {ind.label}
+                      </h3>
+                      <p className="text-sm text-base-content/60 leading-relaxed">{ind.description}</p>
+                      <span className="inline-flex items-center gap-1 mt-4 text-sm font-medium text-warm-dark opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                        Learn more
+                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                        </svg>
+                      </span>
+                    </div>
+                  </Link>
+                ) : (
+                  <div className="h-full p-6 rounded-2xl border border-base-300 bg-base-100">
+                    <h3 className="font-semibold text-lg mb-2 text-base-content">{ind.label}</h3>
+                    <p className="text-sm text-base-content/60 leading-relaxed">{ind.description}</p>
+                  </div>
+                )}
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+
+          <FadeIn delay={0.3}>
+            <button
+              className="mt-10 group inline-flex items-center gap-2 text-warm-dark font-semibold hover:text-warm transition-colors duration-200 cursor-pointer"
+              onClick={() => window.Beacon("open")}
+            >
+              Tell us about your industry
+              <svg className="w-4 h-4 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+              </svg>
+            </button>
+          </FadeIn>
+        </div>
+      </section>
+
+      {/* ===== TEAM ===== */}
+      <section id="team" className="py-24 md:py-32">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our team"
+            title="You are in good hands"
+            description="Our seasoned translators bring together diverse expertise to meet a wide range of translation and interpretation needs."
+          />
+
+          <div className="mt-16 max-w-3xl space-y-0">
+            <Translator
+              fullName="Aggeliki Gkika"
+              imageSrc="/agg_ai.png"
+              shortName="Aggeliki"
+              href="https://www.linkedin.com/in/agkika/"
+              description="Aggeliki specializes in pharmaceutical, medical, clinical and patent translations, ensuring accuracy and professionalism in highly specialized fields."
+              specializations={["Pharmaceutical", "Medical", "Patents", "Clinical"]}
+              index={0}
+            />
+            <Translator
+              fullName="Chrysanthi Partsanaki"
+              imageSrc="/chrysa_ai.png"
+              shortName="Chrysanthi"
+              href="https://www.linkedin.com/in/cpartsanaki/"
+              description="Chrysanthi delivers precision in academic, financial, legal, and maritime translation, complemented by professional Greek/English and Greek/Spanish interpretation services."
+              specializations={["Academic", "Legal", "Maritime", "Interpreting"]}
+              index={1}
+            />
+            <Translator
+              fullName="Anna Maria Chatzistylianou"
+              imageSrc="/am_ai.png"
+              shortName="Anna Maria"
+              href="https://www.linkedin.com/in/amchatzistylianou/"
+              description="Anna Maria is your go-to specialist for maritime and legal translation, delivering linguistic precision with deep industry knowledge."
+              specializations={["Maritime", "Legal", "Subtitling"]}
+              index={2}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ===== TESTIMONIALS ===== */}
+      <TestimonialsSection />
+
+      {/* ===== CTA ===== */}
+      <CTASection
+        eyebrow="Ready to get started?"
+        title="Feel free to contact us!"
+        description="Do you want to translate your new book or find interpreters for your big conference or event? Or do you have another question?"
+        buttonText="Contact us"
+      />
+
+      {/* ===== FOOTER ===== */}
+      <Footer />
+    </div>
   );
 }

--- a/src/app/pharmaceutical-translation/page.tsx
+++ b/src/app/pharmaceutical-translation/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
-import { ServiceCard } from "~/components/Services";
-import LabeledEmoji from "~/components/LabeledEmoji";
-import { Header } from "~/components/Header";
+import { motion } from "framer-motion";
+import { PageHero } from "~/components/PageHero";
+import { SectionHeader } from "~/components/SectionHeader";
+import { CTASection } from "~/components/CTASection";
+import { Footer } from "~/components/Footer";
+import { FadeIn } from "~/components/animations/FadeIn";
+import {
+  StaggerContainer,
+  StaggerItem,
+} from "~/components/animations/StaggerContainer";
 
 declare global {
   interface Window {
@@ -13,321 +19,359 @@ declare global {
   }
 }
 
+const navItems = [
+  { label: "Home", href: "/" },
+  { label: "Our services", href: "#services" },
+  { label: "Quality process", href: "#quality" },
+  { label: "Why us", href: "#why" },
+];
+
 const services = [
   {
-    id: 1,
-    label: "Regulatory Submissions",
-    description: (
-      <>
-        <p className="mb-4">
-          Regulatory-compliant translation of EU submissions and multi-module dossiers with precise terminology management.
-        </p>
-      </>
-    )
+    title: "Regulatory Submissions",
+    description:
+      "Regulatory-compliant translation of EU submissions and multi-module dossiers with precise terminology management.",
   },
   {
-    id: 2,
-    label: "Product Information",
-    description: (
-      <>
-        <p className="mb-4">
-          Translation of SmPCs, package leaflets (PILs), and labeling texts that meet strict regulatory standards.
-        </p>
-      </>
-    )
+    title: "Product Information",
+    description:
+      "Translation of SmPCs, package leaflets (PILs), and labeling texts that meet strict regulatory standards.",
   },
   {
-    id: 3,
-    label: "Clinical Trial Documentation",
-    description: (
-      <>
-        <p className="mb-4">
-          Clinical trial documentation, protocols, and informed consent forms with absolute accuracy and consistency.
-        </p>
-      </>
-    )
+    title: "Clinical Trial Documentation",
+    description:
+      "Clinical trial documentation, protocols, and informed consent forms with absolute accuracy and consistency.",
   },
   {
-    id: 4,
-    label: "Pharmacovigilance & MAH",
-    description: (
-      <>
-        <p className="mb-4">
-          Pharmacovigilance and MAH documentation with audit-ready quality and terminology precision.
-        </p>
-      </>
-    )
+    title: "Pharmacovigilance & MAH",
+    description:
+      "Pharmacovigilance and MAH documentation with audit-ready quality and terminology precision.",
   },
   {
-    id: 5,
-    label: "Patient-Facing Materials",
-    description: (
-      <>
-        <p className="mb-4">
-          Patient-facing and medical materials that balance accuracy with accessibility and clarity.
-        </p>
-      </>
-    )
-  }
+    title: "Patient-Facing Materials",
+    description:
+      "Patient-facing and medical materials that balance accuracy with accessibility and clarity.",
+  },
 ];
 
 const qualityProcess = [
-  { step: "1", title: "Specialist Translation", description: "by life sciences experts" },
-  { step: "2", title: "Independent Review", description: "Four-Eyes Principle verification" },
-  { step: "3", title: "Final Quality Assurance", description: "formatting, consistency, regulatory alignment" }
+  {
+    step: "01",
+    title: "Specialist Translation",
+    description: "by life sciences experts",
+  },
+  {
+    step: "02",
+    title: "Independent Review",
+    description: "Four-Eyes Principle verification",
+  },
+  {
+    step: "03",
+    title: "Final Quality Assurance",
+    description: "formatting, consistency, regulatory alignment",
+  },
+];
+
+const whyUsCards = [
+  {
+    title: "Harmonized Terminology",
+    description:
+      "Harmonized terminology across regulatory and clinical documentation ensures consistency and compliance.",
+  },
+  {
+    title: "Submission Consistency",
+    description:
+      "Consistency between submissions and updates with CAT tools, translation memories, and project glossaries.",
+  },
+  {
+    title: "Secure Workflows",
+    description:
+      "Encrypted, GDPR-compliant workflows protect sensitive data and maintain regulatory standards.",
+  },
 ];
 
 const benefits = [
-  { emoji: "🔒", label: "GDPR-Compliant Workflows" },
-  { emoji: "📋", label: "Harmonized Terminology" },
-  { emoji: "🔄", label: "CAT Tools & Translation Memories" },
-  { emoji: "✓", label: "Audit-Ready Quality" }
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+      </svg>
+    ),
+    label: "GDPR-Compliant Workflows",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15a2.25 2.25 0 012.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25z" />
+      </svg>
+    ),
+    label: "Harmonized Terminology",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 12c0-1.232-.046-2.453-.138-3.662a4.006 4.006 0 00-3.7-3.7 48.678 48.678 0 00-7.324 0 4.006 4.006 0 00-3.7 3.7c-.017.22-.032.441-.046.662M19.5 12l3-3m-3 3l-3-3m-12 3c0 1.232.046 2.453.138 3.662a4.006 4.006 0 003.7 3.7 48.656 48.656 0 007.324 0 4.006 4.006 0 003.7-3.7c.017-.22.032-.441.046-.662M4.5 12l3 3m-3-3l-3 3" />
+      </svg>
+    ),
+    label: "CAT Tools & Translation Memories",
+  },
+  {
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+      </svg>
+    ),
+    label: "Audit-Ready Quality",
+  },
 ];
 
-export default function PharmaceuticalTranslationPage() {
-  const navItems = [
-    { label: "Home", href: "/" },
-    { label: "Our services", href: "#services" },
-    { label: "Quality process", href: "#quality" },
-    { label: "Why us", href: "#why" },
-  ];
+/* Molecular / hexagonal SVG background for the hero */
+const HeroBackground = () => (
+  <>
+    <div className="absolute inset-0 bg-gradient-to-br from-teal-50 via-white to-teal-100/60" />
+    <svg
+      className="absolute inset-0 w-full h-full opacity-[0.07]"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <pattern
+          id="hex"
+          width="56"
+          height="100"
+          patternUnits="userSpaceOnUse"
+          patternTransform="scale(1.4)"
+        >
+          <path
+            d="M28 66L0 50L0 16L28 0L56 16L56 50L28 66L28 100"
+            fill="none"
+            stroke="#0d9488"
+            strokeWidth="1"
+          />
+          <path
+            d="M28 0L28 34L0 50L0 84L28 100L56 84L56 50L28 34"
+            fill="none"
+            stroke="#0d9488"
+            strokeWidth="1"
+          />
+        </pattern>
+      </defs>
+      <rect width="100%" height="100%" fill="url(#hex)" />
+    </svg>
+    {/* Soft teal glow accents */}
+    <div className="absolute top-20 right-20 w-96 h-96 rounded-full bg-teal-400/10 blur-[120px]" />
+    <div className="absolute bottom-10 left-10 w-72 h-72 rounded-full bg-teal-300/10 blur-[100px]" />
+  </>
+);
 
+export default function PharmaceuticalTranslationPage() {
   return (
     <div className="w-full bg-base-100 text-base-content">
-      {/* Hero Section */}
-      <div className="hero-section bg-sl h-full pb-16">
-        <div>
-          <section className="relative w-full overflow-hidden bg-slate-900">
-            <div className="container mx-auto px-4 md:px-8"></div>
-            <Image
-              src="/bg-clinical.jpg"
-              alt="Pharmaceutical documentation"
-              fill
-              className="object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-r from-slate-900 via-slate-900/90 to-transparent"></div>
-            <div className="relative z-10 h-full items-center px-8 lg:px-24">
-              <Header navItems={navItems} />
-              <div className="max-w-xl text-white mt-8">
-                <div>
-                  <h4 className="bg-accent text-accent-content text-xs shadow-lg rounded-3xl inline-block mb-8 px-4 py-2">
-                    Specialized pharmaceutical and life sciences translation
-                  </h4>
-                  <h1 className="text-5xl leading-tight font-bold mb-4">
-                    Where Scientific Precision Meets Regulatory Compliance
-                  </h1>
-                  <p className="text-xl mb-16">
-                    In pharmaceutical and clinical environments, language is part of compliance. A single error in an SmPC, PIL, regulatory dossier, or clinical trial document can delay approvals or raise regulatory scrutiny.
-                  </p>
-                  <div className="flex flex-col sm:flex-row gap-4">
-                    <button
-                      className="btn btn-lg btn-accent"
-                      onClick={() => window.Beacon("open")}
-                    >
-                      Get a free estimate
-                    </button>
-                    <Link
-                      href="/portfolio"
-                      className="btn btn-lg btn-outline btn-accent"
-                    >
-                      View Portfolio
-                    </Link>
-                  </div>
-                </div>
-              </div>
-              <div className="grid grid-cols-1 gap-8 md:grid-cols-3 my-16 text-white">
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Scientific Precision</h4>
-                  <p>Expert translation by life sciences specialists with deep domain knowledge and terminology expertise.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Regulatory Compliance</h4>
-                  <p>All projects follow structured terminology management and strict quality control for submission-ready results.</p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-2">Audit-Ready Quality</h4>
-                  <p>Accurate, consistent, audit-ready medical translation with comprehensive documentation and traceability.</p>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
-
-      {/* About Section */}
-      <div className="container mx-auto">
-        <div className="lg:w-2/3 p-8">
-          <p className="text-2xl mb-2 text-muted-foreground">
-            Athens-based boutique agency
-          </p>
-          <h2 className="text-4xl font-bold mb-8">
-            Expert Translation for <i className="font-normal">Regulated Industries</i>
-          </h2>
-          <p className="text-xl mb-8">
-            We support pharmaceutical, biotech, and life sciences organizations with regulatory-compliant translation services designed for accuracy, consistency, and audit-readiness.
-          </p>
-        </div>
-      </div>
-
-      {/* Services Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8" id="services">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our specialized pharmaceutical services
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Service Portfolio</h2>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mb-8">
-              {services.map((service) => (
-                <ServiceCard
-                  key={service.id}
-                  label={service.label}
-                  description={service.description}
-                />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Quality Process Section */}
-      <div className="bg-base-300">
-        <div className="container mx-auto">
-          <div className="p-8" id="quality">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our quality commitment
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Our Quality Process (TEP)</h2>
-            <p className="text-xl mb-8 lg:w-2/3">
-              Every project undergoes a three-step review to ensure accurate, consistent, audit-ready medical translation.
-            </p>
-            <div className="grid gap-8 grid-cols-1 md:grid-cols-3 mb-8">
-              {qualityProcess.map((item) => (
-                <div key={item.step} className="bg-base-100 p-6 rounded-lg shadow-lg">
-                  <div className="text-accent text-5xl font-bold mb-4">{item.step}</div>
-                  <h3 className="text-2xl font-semibold mb-2">{item.title}</h3>
-                  <p className="text-lg">{item.description}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Why Us Section */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8" id="why">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Why choose us
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Secure. Consistent. Submission-Ready.</h2>
-            <p className="text-xl mb-8 lg:w-2/3">
-              Because pharmaceutical translation is not just about language — it is about precision, compliance, and trust.
-            </p>
-            <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 mb-8">
-              <ServiceCard
-                label="Harmonized Terminology"
-                description="Harmonized terminology across regulatory and clinical documentation ensures consistency and compliance."
-              />
-              <ServiceCard
-                label="Submission Consistency"
-                description="Consistency between submissions and updates with CAT tools, translation memories, and project glossaries."
-              />
-              <ServiceCard
-                label="Secure Workflows"
-                description="Encrypted, GDPR-compliant workflows protect sensitive data and maintain regulatory standards."
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Benefits Section */}
-      <div className="bg-base-300">
-        <div className="container mx-auto">
-          <div className="p-8">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our commitment
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Accuracy in Every Term</h2>
-            <p className="text-xl mb-8 lg:w-2/3">
-              We ensure confidence in every submission through rigorous quality control and domain expertise.
-            </p>
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-              {benefits.map((benefit) => (
-                <LabeledEmoji key={benefit.label} emoji={benefit.emoji} label={benefit.label} />
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* CTA Section */}
-      <div className="hero-section h-full pb-16 text-white" style={{ background: 'linear-gradient(to top right, oklch(27% 0.041 260.031), oklch(44% 0.043 257.281), oklch(27% 0.046 192.524))' }}>
-        <div className="container mx-auto">
-          <div className="xl:w-2/3 p-8 pb-0 text-white">
-            <p className="text-2xl text-slate-400 mb-2">
-              Ready to discuss your pharmaceutical translation project?
-            </p>
-            <h3 className="text-4xl font-bold mb-8">
-              Confidence in Every Submission
-            </h3>
-            <p className="text-xl mb-8 md:w-2/3">
-              Whether it&apos;s regulatory submissions, clinical trial documentation, or patient-facing materials, we have the expertise to deliver excellence.
-            </p>
+      {/* ───── Hero Section ───── */}
+      <PageHero
+        navItems={navItems}
+        badge="Specialized pharmaceutical and life sciences translation"
+        title="Where Scientific Precision Meets Regulatory Compliance"
+        subtitle="In pharmaceutical and clinical environments, language is part of compliance. A single error in an SmPC, PIL, regulatory dossier, or clinical trial document can delay approvals or raise regulatory scrutiny."
+        variant="full"
+        className="!text-slate-900"
+        backgroundElement={<HeroBackground />}
+        cta={
+          <div className="flex flex-col sm:flex-row gap-4">
             <button
-              className="btn btn-accent"
+              className="group relative inline-flex items-center gap-2 bg-teal-600 text-white font-semibold px-8 py-4 rounded-xl hover:bg-teal-700 transition-all duration-300 hover:shadow-lg hover:shadow-teal-600/20"
               onClick={() => window.Beacon("open")}
             >
-              Contact us →
+              Get a free estimate
+              <svg
+                className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 7l5 5m0 0l-5 5m5-5H6"
+                />
+              </svg>
             </button>
+            <Link
+              href="/portfolio"
+              className="inline-flex items-center gap-2 font-semibold px-8 py-4 rounded-xl border-2 border-teal-600 text-teal-700 hover:bg-teal-50 transition-all duration-300"
+            >
+              View Portfolio
+            </Link>
           </div>
-        </div>
-      </div>
+        }
+        features={[
+          {
+            title: "Scientific Precision",
+            description:
+              "Expert translation by life sciences specialists with deep domain knowledge and terminology expertise.",
+          },
+          {
+            title: "Regulatory Compliance",
+            description:
+              "All projects follow structured terminology management and strict quality control for submission-ready results.",
+          },
+          {
+            title: "Audit-Ready Quality",
+            description:
+              "Accurate, consistent, audit-ready medical translation with comprehensive documentation and traceability.",
+          },
+        ]}
+      />
 
-      {/* Footer */}
-      <div className="bg-slate-900">
-        <div className="container mx-auto p-8">
-          <Image
-            alt="Afterwords logo"
-            src="/logo.svg"
-            width={200}
-            height={50}
-            className="mb-8 w-1/3 md:w-1/4"
+      {/* ───── About Section ───── */}
+      <section className="py-20 md:py-28">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Athens-based boutique agency"
+            title="Expert Translation for"
+            titleItalic="Regulated Industries"
+            description="We support pharmaceutical, biotech, and life sciences organizations with regulatory-compliant translation services designed for accuracy, consistency, and audit-readiness."
           />
-          <div className="flex items-center">
-            <h3 className="text-white text-xl mr-4">Find us on social media</h3>
-            <a href="https://www.instagram.com/afterwordstranslations/" className="inline-block mr-4">
-              <Image
-                alt="Instagram logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/insta.svg"
-              />
-            </a>
-            <a href="https://www.linkedin.com/company/afterwordstranslations" className="inline-block mr-4">
-              <Image
-                alt="LinkedIn logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/in.png"
-              />
-            </a>
-            <a href="https://www.facebook.com/AfterWordstranslations" className="inline-block mr-4">
-              <Image
-                alt="Facebook logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/fb.png"
-              />
-            </a>
+        </div>
+      </section>
+
+      {/* ───── Services Section ───── */}
+      <section className="bg-slate-50 py-20 md:py-28" id="services">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our specialized pharmaceutical services"
+            title="Service Portfolio"
+          />
+
+          <StaggerContainer className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-14">
+            {services.map((service) => (
+              <StaggerItem key={service.title}>
+                <div className="group bg-white rounded-xl border border-slate-200 overflow-hidden hover:shadow-lg hover:shadow-teal-500/5 transition-all duration-300 h-full flex">
+                  {/* Teal sidebar indicator */}
+                  <div className="w-1.5 bg-teal-500 shrink-0 group-hover:w-2 transition-all duration-300" />
+                  <div className="p-6">
+                    <h3 className="text-lg font-bold mb-2 text-slate-900">
+                      {service.title}
+                    </h3>
+                    <p className="text-base-content/70 text-sm leading-relaxed">
+                      {service.description}
+                    </p>
+                  </div>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* ───── Quality Process Section (Dashboard-style TEP) ───── */}
+      <section className="py-20 md:py-28 bg-white" id="quality">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our quality commitment"
+            title="Our Quality Process (TEP)"
+            description="Every project undergoes a three-step review to ensure accurate, consistent, audit-ready medical translation."
+          />
+
+          <div className="mt-16 relative">
+            {/* Connecting line (desktop) */}
+            <div className="hidden md:block absolute top-12 left-[calc(16.66%+24px)] right-[calc(16.66%+24px)] h-0.5 bg-gradient-to-r from-teal-400 via-teal-500 to-teal-400" />
+
+            <StaggerContainer className="grid gap-8 grid-cols-1 md:grid-cols-3">
+              {qualityProcess.map((item) => (
+                <StaggerItem key={item.step}>
+                  <div className="flex flex-col items-center text-center">
+                    {/* Numbered circle */}
+                    <div className="relative z-10 w-24 h-24 rounded-full bg-gradient-to-br from-teal-500 to-teal-600 flex items-center justify-center shadow-lg shadow-teal-500/20 mb-6">
+                      <span className="text-white text-2xl font-bold tracking-tight">
+                        {item.step}
+                      </span>
+                    </div>
+                    <h3 className="text-xl font-bold mb-2 text-slate-900">
+                      {item.title}
+                    </h3>
+                    <p className="text-base-content/60 text-sm leading-relaxed max-w-xs">
+                      {item.description}
+                    </p>
+                  </div>
+                </StaggerItem>
+              ))}
+            </StaggerContainer>
           </div>
         </div>
-      </div>
+      </section>
+
+      {/* ───── Why Us Section ───── */}
+      <section className="bg-slate-50 py-20 md:py-28" id="why">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Why choose us"
+            title="Secure. Consistent. Submission-Ready."
+            description="Because pharmaceutical translation is not just about language — it is about precision, compliance, and trust."
+          />
+
+          <StaggerContainer className="grid gap-8 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 mt-14">
+            {whyUsCards.map((card) => (
+              <StaggerItem key={card.title}>
+                <div className="bg-white rounded-xl border border-slate-200 p-8 hover:shadow-lg hover:shadow-teal-500/5 transition-all duration-300 h-full">
+                  {/* Teal top accent */}
+                  <div className="w-10 h-1 rounded-full bg-teal-500 mb-6" />
+                  <h3 className="text-lg font-bold mb-3 text-slate-900">
+                    {card.title}
+                  </h3>
+                  <p className="text-base-content/70 text-sm leading-relaxed">
+                    {card.description}
+                  </p>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* ───── Benefits Badge Bar ───── */}
+      <section className="py-16 bg-white border-y border-slate-100">
+        <div className="container mx-auto px-8">
+          <FadeIn>
+            <div className="flex flex-col items-center">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] mb-2 text-warm-dark">
+                Our commitment
+              </p>
+              <h2 className="font-[family-name:var(--font-display)] text-3xl md:text-4xl font-bold mb-3 text-center text-slate-900">
+                Accuracy in Every Term
+              </h2>
+              <p className="text-base-content/70 text-center mb-10 max-w-xl">
+                We ensure confidence in every submission through rigorous quality control and domain expertise.
+              </p>
+            </div>
+          </FadeIn>
+
+          <StaggerContainer className="flex flex-wrap justify-center gap-4">
+            {benefits.map((benefit) => (
+              <StaggerItem key={benefit.label}>
+                <motion.div
+                  whileHover={{ scale: 1.04 }}
+                  className="inline-flex items-center gap-3 bg-teal-50 border border-teal-200 text-teal-800 rounded-full px-6 py-3 text-sm font-medium"
+                >
+                  <span className="text-teal-600">{benefit.icon}</span>
+                  {benefit.label}
+                </motion.div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
+        </div>
+      </section>
+
+      {/* ───── CTA ───── */}
+      <CTASection
+        eyebrow="Ready to discuss your pharmaceutical translation project?"
+        title="Confidence in Every Submission"
+        description="Whether it's regulatory submissions, clinical trial documentation, or patient-facing materials, we have the expertise to deliver excellence."
+        buttonText="Contact us"
+      />
+
+      {/* ───── Footer ───── */}
+      <Footer />
     </div>
   );
 }

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,8 +1,20 @@
 "use client";
-
-import Image from "next/image";
 import Link from "next/link";
-import { Header } from "~/components/Header";
+import { motion } from "framer-motion";
+import { PageHero } from "~/components/PageHero";
+import { SectionHeader } from "~/components/SectionHeader";
+import { CTASection } from "~/components/CTASection";
+import { Footer } from "~/components/Footer";
+import { FadeIn } from "~/components/animations/FadeIn";
+import { CountUp } from "~/components/animations/CountUp";
+import { StaggerContainer, StaggerItem } from "~/components/animations/StaggerContainer";
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line
+    Beacon: any;
+  }
+}
 
 const portfolioItems = [
   {
@@ -10,338 +22,300 @@ const portfolioItems = [
     emoji: "🧬",
     title: "Medical & Scientific Innovations",
     category: "Specialized Translation",
-    description: "Expert translations for the medical and scientific sectors, including patent specifications, pharmaceutical applications, clinical research, and healthcare documentation.",
+    description:
+      "Expert translations for the medical and scientific sectors, including patent specifications, pharmaceutical applications, clinical research, and healthcare documentation.",
     items: [
       "Patent Specifications: Annual translation of 200–300 patent specifications specializing in biology, chemistry, biochemistry, and technology.",
       "Pharmaceutical Applications: Translation of 150–200 patent applications and abstracts per year.",
       "Clinical Research: Translation of clinical trial documents, medical research papers, and articles for publication.",
-      "Healthcare Documentation: Comprehensive translation of patient records and medical reports."
+      "Healthcare Documentation: Comprehensive translation of patient records and medical reports.",
     ],
-    stats: {
-      patents: "300/year",
-      applications: "200/year",
-      documents: "1000+"
-    }
+    stats: [
+      { value: 300, suffix: "/yr", label: "Patents" },
+      { value: 200, suffix: "/yr", label: "Applications" },
+      { value: 1000, suffix: "+", label: "Documents" },
+    ],
+    accent: "from-teal-500/10 to-emerald-500/10",
+    borderAccent: "border-l-teal-500",
   },
   {
     id: 2,
     emoji: "⚖️",
     title: "Legal & Financial Compliance",
     category: "Corporate Translation",
-    description: "Certified translations for international business operations, corporate governance, global finance, market intelligence, and international law.",
+    description:
+      "Certified translations for international business operations, corporate governance, global finance, market intelligence, and international law.",
     items: [
       "Corporate Governance: Translation of contracts, agreements, and certificates for international business operations.",
       "Global Finance: Preparation of financial reports, balance sheets, and income statements.",
       "Market Intelligence: Translation of investment research reports and market analyses.",
-      "International Law: Translation of treaties, conventions, and residency applications."
+      "International Law: Translation of treaties, conventions, and residency applications.",
     ],
-    stats: {
-      contracts: "300+",
-      reports: "200+",
-      clients: "50+"
-    }
+    stats: [
+      { value: 300, suffix: "+", label: "Contracts" },
+      { value: 200, suffix: "+", label: "Reports" },
+      { value: 50, suffix: "+", label: "Clients" },
+    ],
+    accent: "from-blue-500/10 to-indigo-500/10",
+    borderAccent: "border-l-blue-500",
   },
   {
     id: 3,
     emoji: "📚",
     title: "Published Books (Greek Editions)",
     category: "Literary Translation",
-    description: "High-quality translations of academic and scholarly books, preserving intellectual rigor and authorial voice for Greek readers.",
+    description:
+      "High-quality translations of academic and scholarly books, preserving intellectual rigor and authorial voice for Greek readers.",
     items: [
       "The Sociology of Health and Illness (4th Edition) by Sarah Nettleton.",
       "Development Economics: Theory and Practice (2nd Edition) by Alain de Janvry & Elisabeth Sadoulet.",
       "Managerial Economics in a Global Economy (9th Edition) by Dominick Salvatore.",
       "Mathematics for Economics: An Integrated Approach by Mik Wisniewski.",
-      "Child Observation: A Guide for Students of Early Childhood (4th Edition) by Ioanna Palaiologou."
+      "Child Observation: A Guide for Students of Early Childhood (4th Edition) by Ioanna Palaiologou.",
     ],
-    stats: {
-      books: "5+",
-      pages: "2000+",
-      publishers: "3"
-    }
+    stats: [
+      { value: 5, suffix: "+", label: "Books" },
+      { value: 2000, suffix: "+", label: "Pages" },
+      { value: 3, suffix: "", label: "Publishers" },
+    ],
+    accent: "from-amber-500/10 to-orange-500/10",
+    borderAccent: "border-l-amber-500",
   },
   {
     id: 4,
     emoji: "🎬",
     title: "Media & Events",
     category: "Subtitling & Interpreting",
-    description: "Professional subtitling services for TV series, films, and festivals, along with specialized interpreting for corporate conferences and the aviation sector.",
+    description:
+      "Professional subtitling services for TV series, films, and festivals, along with specialized interpreting for corporate conferences and the aviation sector.",
     items: [
-      "TV Series Localization: Greek subtitles for the hit series \"Black-ish\".",
+      'TV Series Localization: Greek subtitles for the hit series "Black-ish".',
       "Film Festivals: Subtitling for the Beyond Borders International Festival (2019–2022).",
-      "Cinema: English and French subtitles for the Greek short film \"MAUVE\".",
+      'Cinema: English and French subtitles for the Greek short film "MAUVE".',
       "Corporate Conferences: Interpreting for the Coating Forum (2022–2023) and pharmaceutical launches.",
-      "Aviation Sector: Specialized interpreting for business meetings and technical presentations."
+      "Aviation Sector: Specialized interpreting for business meetings and technical presentations.",
     ],
-    stats: {
-      series: "1",
-      festivals: "4 years",
-      events: "50+"
-    }
-  }
+    stats: [
+      { value: 1, suffix: "", label: "Series" },
+      { value: 4, suffix: " yrs", label: "Festivals" },
+      { value: 50, suffix: "+", label: "Events" },
+    ],
+    accent: "from-purple-500/10 to-pink-500/10",
+    borderAccent: "border-l-purple-500",
+  },
+];
+
+const expertiseAreas = [
+  {
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+      </svg>
+    ),
+    title: "Translation",
+    description: "Accurate translation of documents, websites, and content across all major languages",
+    color: "text-teal-600",
+  },
+  {
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
+      </svg>
+    ),
+    title: "Localization",
+    description: "Cultural adaptation of products, websites, and marketing for local markets",
+    color: "text-blue-600",
+  },
+  {
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
+      </svg>
+    ),
+    title: "Transcreation",
+    description: "Creative translation that preserves brand voice and emotional impact",
+    color: "text-amber-600",
+  },
+  {
+    icon: (
+      <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+      </svg>
+    ),
+    title: "Cultural Consulting",
+    description: "Expert guidance on cultural nuances and market-specific communication strategies",
+    color: "text-purple-600",
+  },
 ];
 
 export default function PortfolioPage() {
-  const navItems = [
-    { label: "Home", href: "/" },
-  ];
+  const navItems = [{ label: "Home", href: "/" }];
 
   return (
     <div className="w-full bg-base-100 text-base-content">
-      {/* Header */}
-      <div className="hero-section bg-sl h-full">
-        <section className="relative w-full overflow-hidden bg-slate-900">
-          <div className="container mx-auto px-4 md:px-8"></div>
-          <Image
-            src="/bg.jpg"
-            alt="Professional signing document"
-            fill
-            className="object-cover"
+      {/* ===== HERO ===== */}
+      <PageHero
+        navItems={navItems}
+        badge="Showcasing our expertise across specialized translation domains"
+        title="Our Portfolio"
+        subtitle="Explore our portfolio of translation and localization projects. From medical patents to published books, we deliver precision and cultural expertise across industries."
+        variant="compact"
+        cta={
+          <div className="flex flex-col sm:flex-row gap-4">
+            <button
+              className="group inline-flex items-center gap-2 bg-warm text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-warm-dark hover:text-white transition-all duration-300 hover:shadow-lg hover:shadow-warm/20 cursor-pointer"
+              onClick={() => window.Beacon("open")}
+            >
+              Get a free estimate
+              <svg className="w-4 h-4 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+              </svg>
+            </button>
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 border border-white/20 text-white font-semibold px-8 py-4 rounded-xl hover:bg-white/10 transition-all duration-300"
+            >
+              Back to Home
+            </Link>
+          </div>
+        }
+        features={[
+          { title: "Subject Matter Experts", description: "Specialized translators with deep domain expertise in medical, legal, and technical fields." },
+          { title: "TEP Workflow", description: "Gold-standard Translation, Editing, Proofreading workflow ensures quality and accuracy." },
+          { title: "Proven Track Record", description: "From medical patents to published books, we deliver excellence across all project types." },
+        ]}
+        backgroundElement={
+          <div className="absolute inset-0">
+            <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-primary/90 to-slate-900" />
+            <div className="absolute top-1/3 right-0 w-[400px] h-[400px] rounded-full bg-warm/8 blur-[120px]" />
+          </div>
+        }
+      />
+
+      {/* ===== ABOUT ===== */}
+      <section className="py-24 md:py-32">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our work"
+            title="We strive for"
+            titleItalic="Excellence Across Industries"
+            description="Our portfolio spans specialized translation domains, from medical patents and legal compliance to literary publishing and media localization."
           />
-          <div className="absolute inset-0 bg-gradient-to-r from-slate-900 via-slate-900/90 to-transparent"></div>
+          <FadeIn delay={0.2}>
+            <p className="text-lg text-base-content/70 leading-relaxed mt-4 max-w-3xl">
+              Each project demonstrates our commitment to precision, cultural expertise, and professional excellence. We leverage subject matter expertise and advanced Translation Memories to deliver consistent, high-quality results.
+            </p>
+          </FadeIn>
+        </div>
+      </section>
 
-          <div className="relative z-10 h-full items-center px-8 lg:px-24">
-            <Header navItems={navItems} />
+      {/* ===== PORTFOLIO ITEMS — Full-Width Case Studies ===== */}
+      {portfolioItems.map((item, index) => (
+        <section
+          key={item.id}
+          className={`py-20 md:py-28 ${index % 2 === 0 ? "bg-base-200" : "bg-base-100"}`}
+        >
+          <div className="container mx-auto px-8">
+            <motion.div
+              initial={{ opacity: 0, y: 40 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-100px" }}
+              transition={{ duration: 0.6 }}
+            >
+              {/* Category + Emoji */}
+              <div className="flex items-center gap-4 mb-6">
+                <span className="text-5xl">{item.emoji}</span>
+                <span className="text-sm font-semibold uppercase tracking-[0.15em] text-warm-dark">
+                  {item.category}
+                </span>
+              </div>
 
-            {/* Hero Section */}
-            <div className="max-w-xl text-white mt-8">
-              <div>
-                <h4 className="bg-accent text-accent-content text-xs shadow-lg rounded-3xl inline-block mb-8 px-4 py-2">
-                  Showcasing our expertise across specialized translation domains
-                </h4>
-                <h1 className="text-5xl leading-tight font-bold mb-4">
-                  Our Portfolio
-                </h1>
-                <p className="text-xl mb-16">
-                  Explore our portfolio of translation and localization projects. From medical patents to published books, we deliver precision and cultural expertise across industries.
-                </p>
-                <div className="flex flex-col sm:flex-row gap-4">
-                  <button
-                    className="btn btn-lg btn-accent"
-                    onClick={() => {
-                      if (typeof window !== 'undefined' && window.Beacon) {
-                        window.Beacon("open");
-                      }
-                    }}
-                  >
-                    Get a free estimate
-                  </button>
-                  <Link
-                    href="/"
-                    className="btn btn-lg btn-outline btn-accent"
-                  >
-                    Back to Home
-                  </Link>
+              <h3 className="font-[family-name:var(--font-display)] text-3xl md:text-4xl font-bold mb-4 text-base-content">
+                {item.title}
+              </h3>
+
+              <p className="text-lg text-base-content/60 leading-relaxed max-w-3xl mb-10">
+                {item.description}
+              </p>
+
+              {/* Two column: items + stats */}
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
+                {/* Detail items */}
+                <div className="lg:col-span-2 space-y-4">
+                  {item.items.map((listItem, idx) => (
+                    <motion.div
+                      key={idx}
+                      className={`flex gap-4 p-4 rounded-xl bg-gradient-to-r ${item.accent} border-l-4 ${item.borderAccent}`}
+                      initial={{ opacity: 0, x: -20 }}
+                      whileInView={{ opacity: 1, x: 0 }}
+                      viewport={{ once: true }}
+                      transition={{ duration: 0.4, delay: idx * 0.1 }}
+                    >
+                      <span className="text-base-content/80 text-sm leading-relaxed">
+                        {listItem}
+                      </span>
+                    </motion.div>
+                  ))}
+                </div>
+
+                {/* Stats */}
+                <div className="flex flex-row lg:flex-col gap-6 lg:gap-8 justify-start">
+                  {item.stats.map((stat) => (
+                    <div key={stat.label} className="text-center lg:text-left">
+                      <div className="text-3xl md:text-4xl font-bold text-base-content">
+                        <CountUp end={stat.value} suffix={stat.suffix} />
+                      </div>
+                      <p className="text-sm text-base-content/50 font-medium mt-1">
+                        {stat.label}
+                      </p>
+                    </div>
+                  ))}
                 </div>
               </div>
-            </div>
-
-            {/* Hero Features Grid */}
-            <div className="grid grid-cols-1 gap-8 md:grid-cols-3 my-16 text-white">
-              <div>
-                <h4 className="text-lg font-semibold mb-2">Subject Matter Experts</h4>
-                <p>Specialized translators with deep domain expertise in medical, legal, and technical fields.</p>
-              </div>
-              <div>
-                <h4 className="text-lg font-semibold mb-2">TEP Workflow</h4>
-                <p>Gold-standard Translation, Editing, Proofreading workflow ensures quality and accuracy.</p>
-              </div>
-              <div>
-                <h4 className="text-lg font-semibold mb-2">Proven Track Record</h4>
-                <p>From medical patents to published books, we deliver excellence across all project types.</p>
-              </div>
-            </div>
+            </motion.div>
           </div>
         </section>
-      </div>
+      ))}
 
-      {/* About Section */}
-      <div className="container mx-auto">
-        <div className="lg:w-2/3 p-8">
-          <p className="text-2xl mb-2 text-muted-foreground">
-            Our work
-          </p>
-          <h2 className="text-4xl font-bold mb-8">
-            We strive for <i className="font-normal">Excellence</i> Across Industries
-          </h2>
-          <p className="text-xl mb-4">
-            Our portfolio spans specialized translation domains, from medical patents and legal compliance to literary publishing and media localization.
-          </p>
-          <p className="text-xl mb-8">
-            Each project demonstrates our commitment to precision, cultural expertise, and professional excellence. We leverage subject matter expertise and advanced Translation Memories to deliver consistent, high-quality results.
-          </p>
-        </div>
-      </div>
-
-      {/* Portfolio Items */}
-      <div className="bg-base-300">
-        <div className="container mx-auto">
-          <div className="p-8">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Featured Projects
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Showcasing our expertise and commitment to quality</h2>
-
-            <div className="grid gap-8 md:grid-cols-2">
-              {portfolioItems.map((item) => (
-                <div
-                  key={item.id}
-                  className="bg-base-100 rounded-lg p-8 shadow-lg hover:shadow-xl transition-shadow"
-                >
-                  <div className="text-6xl mb-4">{item.emoji}</div>
-                  <div className="text-sm text-accent font-semibold mb-2">
-                    {item.category}
-                  </div>
-
-                  <h3 className="text-2xl font-bold mb-3">
-                    {item.title}
-                  </h3>
-
-                  <p className="text-muted-foreground mb-6">
-                    {item.description}
-                  </p>
-
-                  {/* Detailed Items List */}
-                  <div className="space-y-3 mb-6">
-                    {item.items.map((listItem, idx) => (
-                      <div key={idx} className="flex gap-3 text-sm">
-                        <span className="text-accent font-bold mt-1">•</span>
-                        <span className="text-base-content/90">{listItem}</span>
-                      </div>
-                    ))}
-                  </div>
-
-                  {/* Stats */}
-                  <div className="grid grid-cols-3 gap-2 pt-4 border-t border-base-300">
-                    {Object.entries(item.stats).map(([key, value]) => (
-                      <div key={key} className="text-center">
-                        <div className="text-lg font-bold text-accent">{value}</div>
-                        <div className="text-xs text-muted-foreground capitalize">{key}</div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Services Highlight */}
-      <div className="bg-base-100">
-        <div className="container mx-auto">
-          <div className="p-8">
-            <p className="text-2xl mb-2 text-muted-foreground">
-              Our Expertise
-            </p>
-            <h2 className="text-4xl font-bold mb-8">Comprehensive language services tailored to your needs</h2>
-
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
-              <div className="text-center p-6">
-                <div className="text-5xl mb-4">📝</div>
-                <h3 className="text-xl font-bold mb-2">Translation</h3>
-                <p className="text-muted-foreground">
-                  Accurate translation of documents, websites, and content across all major languages
-                </p>
-              </div>
-
-              <div className="text-center p-6">
-                <div className="text-5xl mb-4">🌐</div>
-                <h3 className="text-xl font-bold mb-2">Localization</h3>
-                <p className="text-muted-foreground">
-                  Cultural adaptation of products, websites, and marketing for local markets
-                </p>
-              </div>
-
-              <div className="text-center p-6">
-                <div className="text-5xl mb-4">✨</div>
-                <h3 className="text-xl font-bold mb-2">Transcreation</h3>
-                <p className="text-muted-foreground">
-                  Creative translation that preserves brand voice and emotional impact
-                </p>
-              </div>
-
-              <div className="text-center p-6">
-                <div className="text-5xl mb-4">🎯</div>
-                <h3 className="text-xl font-bold mb-2">Cultural Consulting</h3>
-                <p className="text-muted-foreground">
-                  Expert guidance on cultural nuances and market-specific communication strategies
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* CTA Section */}
-      <div className="hero-section h-full pb-16 text-white" style={{ background: 'linear-gradient(to top right, oklch(27% 0.041 260.031), oklch(44% 0.043 257.281), oklch(27% 0.046 192.524))' }}>
-        <div className="container mx-auto">
-          <div className="xl:w-2/3 p-8 pb-0 text-white">
-            <p className="text-2xl text-slate-400 mb-2">
-              Ready to start your translation project?
-            </p>
-            <h3 className="text-4xl font-bold mb-8">
-              Let&apos;s discuss your needs
-            </h3>
-            <p className="text-xl mb-8 md:w-2/3">
-              Whether you need specialized translation, certified documents, or media localization, we deliver quality, speed, and reliability.
-            </p>
-            <button
-              className="btn btn-accent"
-              onClick={() => {
-                if (typeof window !== 'undefined' && window.Beacon) {
-                  window.Beacon("open");
-                }
-              }}
-            >
-              Contact us →
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Footer */}
-      <div className="bg-slate-900">
-        <div className="container mx-auto p-8">
-          <Image
-            alt="Afterwords logo"
-            src="/logo.svg"
-            width={200}
-            height={50}
-            className="mb-8 w-1/3 md:w-1/4"
+      {/* ===== EXPERTISE ===== */}
+      <section className="py-24 md:py-32">
+        <div className="container mx-auto px-8">
+          <SectionHeader
+            eyebrow="Our Expertise"
+            title="Comprehensive language services"
+            titleItalic="tailored to your needs"
           />
-          <div className="flex items-center">
-            <h3 className="text-white text-xl mr-4">Find us on social media</h3>
-            <a href="https://www.instagram.com/afterwordstranslations/" className="inline-block mr-4">
-              <Image
-                alt="Instagram logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/insta.svg"
-              />
-            </a>
-            <a href="https://www.linkedin.com/company/afterwordstranslations" className="inline-block mr-4">
-              <Image
-                alt="LinkedIn logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/in.png"
-              />
-            </a>
-            <a href="https://www.facebook.com/AfterWordstranslations" className="inline-block mr-4">
-              <Image
-                alt="Facebook logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/fb.png"
-              />
-            </a>
-          </div>
+
+          <StaggerContainer className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mt-16">
+            {expertiseAreas.map((area) => (
+              <StaggerItem key={area.title}>
+                <div className="group p-6 rounded-2xl border border-base-300 hover:shadow-lg hover:border-warm/30 transition-all duration-300 bg-base-100">
+                  <div className={`${area.color} mb-4 group-hover:scale-110 transition-transform duration-300`}>
+                    {area.icon}
+                  </div>
+                  <h3 className="font-[family-name:var(--font-display)] text-xl font-bold mb-2 text-base-content">
+                    {area.title}
+                  </h3>
+                  <p className="text-sm text-base-content/60 leading-relaxed">
+                    {area.description}
+                  </p>
+                </div>
+              </StaggerItem>
+            ))}
+          </StaggerContainer>
         </div>
-      </div>
+      </section>
+
+      {/* ===== CTA ===== */}
+      <CTASection
+        eyebrow="Ready to start your translation project?"
+        title="Let's discuss your needs"
+        description="Whether you need specialized translation, certified documents, or media localization, we deliver quality, speed, and reliability."
+        buttonText="Contact us"
+      />
+
+      {/* ===== FOOTER ===== */}
+      <Footer />
     </div>
   );
 }

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -5,7 +5,6 @@ import { PageHero } from "~/components/PageHero";
 import { SectionHeader } from "~/components/SectionHeader";
 import { CTASection } from "~/components/CTASection";
 import { Footer } from "~/components/Footer";
-import { FadeIn } from "~/components/animations/FadeIn";
 import { CountUp } from "~/components/animations/CountUp";
 import { StaggerContainer, StaggerItem } from "~/components/animations/StaggerContainer";
 
@@ -19,7 +18,6 @@ declare global {
 const portfolioItems = [
   {
     id: 1,
-    emoji: "🧬",
     title: "Medical & Scientific Innovations",
     category: "Specialized Translation",
     description:
@@ -35,12 +33,10 @@ const portfolioItems = [
       { value: 200, suffix: "/yr", label: "Applications" },
       { value: 1000, suffix: "+", label: "Documents" },
     ],
-    accent: "from-teal-500/10 to-emerald-500/10",
     borderAccent: "border-l-teal-500",
   },
   {
     id: 2,
-    emoji: "⚖️",
     title: "Legal & Financial Compliance",
     category: "Corporate Translation",
     description:
@@ -56,12 +52,10 @@ const portfolioItems = [
       { value: 200, suffix: "+", label: "Reports" },
       { value: 50, suffix: "+", label: "Clients" },
     ],
-    accent: "from-blue-500/10 to-indigo-500/10",
     borderAccent: "border-l-blue-500",
   },
   {
     id: 3,
-    emoji: "📚",
     title: "Published Books (Greek Editions)",
     category: "Literary Translation",
     description:
@@ -78,12 +72,10 @@ const portfolioItems = [
       { value: 2000, suffix: "+", label: "Pages" },
       { value: 3, suffix: "", label: "Publishers" },
     ],
-    accent: "from-amber-500/10 to-orange-500/10",
     borderAccent: "border-l-amber-500",
   },
   {
     id: 4,
-    emoji: "🎬",
     title: "Media & Events",
     category: "Subtitling & Interpreting",
     description:
@@ -100,7 +92,6 @@ const portfolioItems = [
       { value: 4, suffix: " yrs", label: "Festivals" },
       { value: 50, suffix: "+", label: "Events" },
     ],
-    accent: "from-purple-500/10 to-pink-500/10",
     borderAccent: "border-l-purple-500",
   },
 ];
@@ -114,7 +105,8 @@ const expertiseAreas = [
     ),
     title: "Translation",
     description: "Accurate translation of documents, websites, and content across all major languages",
-    color: "text-teal-600",
+    iconColor: "text-teal-500",
+    borderColor: "border-t-teal-500",
   },
   {
     icon: (
@@ -124,7 +116,8 @@ const expertiseAreas = [
     ),
     title: "Localization",
     description: "Cultural adaptation of products, websites, and marketing for local markets",
-    color: "text-blue-600",
+    iconColor: "text-blue-500",
+    borderColor: "border-t-blue-500",
   },
   {
     icon: (
@@ -134,7 +127,8 @@ const expertiseAreas = [
     ),
     title: "Transcreation",
     description: "Creative translation that preserves brand voice and emotional impact",
-    color: "text-amber-600",
+    iconColor: "text-amber-500",
+    borderColor: "border-t-amber-500",
   },
   {
     icon: (
@@ -144,7 +138,8 @@ const expertiseAreas = [
     ),
     title: "Cultural Consulting",
     description: "Expert guidance on cultural nuances and market-specific communication strategies",
-    color: "text-purple-600",
+    iconColor: "text-purple-500",
+    borderColor: "border-t-purple-500",
   },
 ];
 
@@ -156,9 +151,9 @@ export default function PortfolioPage() {
       {/* ===== HERO ===== */}
       <PageHero
         navItems={navItems}
-        badge="Showcasing our expertise across specialized translation domains"
+        badge="Our Work"
         title="Our Portfolio"
-        subtitle="Explore our portfolio of translation and localization projects. From medical patents to published books, we deliver precision and cultural expertise across industries."
+        subtitle="From medical patents to published books, we deliver precision and cultural expertise across specialized translation domains."
         variant="compact"
         cta={
           <div className="flex flex-col sm:flex-row gap-4">
@@ -186,34 +181,17 @@ export default function PortfolioPage() {
         ]}
         backgroundElement={
           <div className="absolute inset-0">
-            <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-primary/90 to-slate-900" />
+            <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900" />
             <div className="absolute top-1/3 right-0 w-[400px] h-[400px] rounded-full bg-warm/8 blur-[120px]" />
           </div>
         }
       />
 
-      {/* ===== ABOUT ===== */}
-      <section className="py-24 md:py-32">
-        <div className="container mx-auto px-8">
-          <SectionHeader
-            eyebrow="Our work"
-            title="We strive for"
-            titleItalic="Excellence Across Industries"
-            description="Our portfolio spans specialized translation domains, from medical patents and legal compliance to literary publishing and media localization."
-          />
-          <FadeIn delay={0.2}>
-            <p className="text-lg text-base-content/70 leading-relaxed mt-4 max-w-3xl">
-              Each project demonstrates our commitment to precision, cultural expertise, and professional excellence. We leverage subject matter expertise and advanced Translation Memories to deliver consistent, high-quality results.
-            </p>
-          </FadeIn>
-        </div>
-      </section>
-
       {/* ===== PORTFOLIO ITEMS — Full-Width Case Studies ===== */}
       {portfolioItems.map((item, index) => (
         <section
           key={item.id}
-          className={`py-20 md:py-28 ${index % 2 === 0 ? "bg-base-200" : "bg-base-100"}`}
+          className={`py-24 md:py-32 ${index % 2 === 0 ? "bg-base-200" : "bg-base-100"}`}
         >
           <div className="container mx-auto px-8">
             <motion.div
@@ -222,30 +200,21 @@ export default function PortfolioPage() {
               viewport={{ once: true, margin: "-100px" }}
               transition={{ duration: 0.6 }}
             >
-              {/* Category + Emoji */}
-              <div className="flex items-center gap-4 mb-6">
-                <span className="text-5xl">{item.emoji}</span>
-                <span className="text-sm font-semibold uppercase tracking-[0.15em] text-warm-dark">
-                  {item.category}
-                </span>
-              </div>
-
-              <h3 className="font-[family-name:var(--font-display)] text-3xl md:text-4xl font-bold mb-4 text-base-content">
-                {item.title}
-              </h3>
-
-              <p className="text-lg text-base-content/60 leading-relaxed max-w-3xl mb-10">
-                {item.description}
-              </p>
+              <SectionHeader
+                eyebrow={item.category}
+                title={item.title}
+                description={item.description}
+                className="mb-12"
+              />
 
               {/* Two column: items + stats */}
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
                 {/* Detail items */}
-                <div className="lg:col-span-2 space-y-4">
+                <div className="lg:col-span-2 space-y-3">
                   {item.items.map((listItem, idx) => (
                     <motion.div
                       key={idx}
-                      className={`flex gap-4 p-4 rounded-xl bg-gradient-to-r ${item.accent} border-l-4 ${item.borderAccent}`}
+                      className={`card-surface p-4 rounded-xl border border-base-300 border-l-4 ${item.borderAccent}`}
                       initial={{ opacity: 0, x: -20 }}
                       whileInView={{ opacity: 1, x: 0 }}
                       viewport={{ once: true }}
@@ -286,11 +255,11 @@ export default function PortfolioPage() {
             titleItalic="tailored to your needs"
           />
 
-          <StaggerContainer className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mt-16">
+          <StaggerContainer className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-16">
             {expertiseAreas.map((area) => (
               <StaggerItem key={area.title}>
-                <div className="group p-6 rounded-2xl border border-base-300 hover:shadow-lg hover:border-warm/30 transition-all duration-300 bg-base-100">
-                  <div className={`${area.color} mb-4 group-hover:scale-110 transition-transform duration-300`}>
+                <div className={`card-surface group p-6 rounded-2xl border border-base-300 border-t-4 ${area.borderColor} hover:shadow-lg transition-all duration-300`}>
+                  <div className={`${area.iconColor} mb-4 group-hover:scale-110 transition-transform duration-300`}>
                     {area.icon}
                   </div>
                   <h3 className="font-[family-name:var(--font-display)] text-xl font-bold mb-2 text-base-content">

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -15,13 +15,7 @@ export const CTASection = ({
   buttonText = "Contact us",
 }: CTASectionProps) => {
   return (
-    <section
-      className="relative py-24 md:py-32 overflow-hidden"
-      style={{
-        background:
-          "linear-gradient(135deg, oklch(27% 0.041 260.031), oklch(35% 0.045 240), oklch(27% 0.046 192.524))",
-      }}
-    >
+    <section className="relative py-24 md:py-32 overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
       {/* Warm accent glow */}
       <div className="absolute top-0 right-0 w-96 h-96 rounded-full bg-warm/10 blur-[120px]" />
       <div className="absolute bottom-0 left-1/4 w-64 h-64 rounded-full bg-warm/5 blur-[100px]" />

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { FadeIn } from "./animations/FadeIn";
+
+interface CTASectionProps {
+  eyebrow: string;
+  title: string;
+  description: string;
+  buttonText?: string;
+}
+
+export const CTASection = ({
+  eyebrow,
+  title,
+  description,
+  buttonText = "Contact us",
+}: CTASectionProps) => {
+  return (
+    <section
+      className="relative py-24 md:py-32 overflow-hidden"
+      style={{
+        background:
+          "linear-gradient(135deg, oklch(27% 0.041 260.031), oklch(35% 0.045 240), oklch(27% 0.046 192.524))",
+      }}
+    >
+      {/* Warm accent glow */}
+      <div className="absolute top-0 right-0 w-96 h-96 rounded-full bg-warm/10 blur-[120px]" />
+      <div className="absolute bottom-0 left-1/4 w-64 h-64 rounded-full bg-warm/5 blur-[100px]" />
+
+      <div className="container mx-auto px-8 relative z-10">
+        <div className="max-w-2xl">
+          <FadeIn>
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] mb-4 text-warm">
+              {eyebrow}
+            </p>
+          </FadeIn>
+          <FadeIn delay={0.1}>
+            <h2 className="font-[family-name:var(--font-display)] text-4xl md:text-5xl font-bold mb-6 text-white leading-tight">
+              {title}
+            </h2>
+          </FadeIn>
+          <FadeIn delay={0.2}>
+            <p className="text-lg md:text-xl text-white/80 mb-10 leading-relaxed">
+              {description}
+            </p>
+          </FadeIn>
+          <FadeIn delay={0.3}>
+            <button
+              className="group relative inline-flex items-center gap-2 bg-warm text-slate-900 font-semibold px-8 py-4 rounded-xl hover:bg-warm-dark hover:text-white transition-all duration-300 hover:shadow-lg hover:shadow-warm/20"
+              onClick={() => window.Beacon("open")}
+            >
+              {buttonText}
+              <svg
+                className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 7l5 5m0 0l-5 5m5-5H6"
+                />
+              </svg>
+            </button>
+          </FadeIn>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/DecadeSection.tsx
+++ b/src/components/DecadeSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { CountUp } from "./animations/CountUp";
-import { FadeIn } from "./animations/FadeIn";
+import { SectionHeader } from "./SectionHeader";
 import { StaggerContainer, StaggerItem } from "./animations/StaggerContainer";
 
 const stats = [
@@ -60,13 +60,7 @@ export const DecadeSection = () => {
   return (
     <section className="relative py-24 md:py-32 overflow-hidden">
       {/* Background */}
-      <div
-        className="absolute inset-0"
-        style={{
-          background:
-            "linear-gradient(135deg, oklch(27% 0.041 260.031) 0%, oklch(35% 0.05 200) 50%, oklch(30% 0.04 60) 100%)",
-        }}
-      />
+      <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900" />
       {/* Warm glow */}
       <div className="absolute top-1/2 right-0 w-[500px] h-[500px] -translate-y-1/2 rounded-full bg-warm/8 blur-[150px]" />
 
@@ -76,22 +70,13 @@ export const DecadeSection = () => {
       </div>
 
       <div className="container mx-auto px-8 relative z-10">
-        <FadeIn>
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] mb-4 text-warm">
-            10th Anniversary
-          </p>
-        </FadeIn>
-        <FadeIn delay={0.1}>
-          <h2 className="font-[family-name:var(--font-display)] text-4xl md:text-5xl font-bold mb-4 text-white">
-            Our Decade of Excellence
-          </h2>
-        </FadeIn>
-        <FadeIn delay={0.2}>
-          <p className="text-lg md:text-xl max-w-2xl leading-relaxed text-white/70 mb-16">
-            Since 2015 we have been bridging languages and cultures across
-            industries with precision and care.
-          </p>
-        </FadeIn>
+        <SectionHeader
+          eyebrow="10th Anniversary"
+          title="Our Decade of Excellence"
+          description="Since 2015 we have been bridging languages and cultures across industries with precision and care."
+          light
+          className="mb-16"
+        />
 
         <StaggerContainer className="grid grid-cols-2 lg:grid-cols-4 gap-8">
           {stats.map((stat) => (

--- a/src/components/DecadeSection.tsx
+++ b/src/components/DecadeSection.tsx
@@ -1,75 +1,118 @@
-import Emoji from "a11y-react-emoji";
-import { StatCard } from "./StatCard";
+"use client";
+import { CountUp } from "./animations/CountUp";
+import { FadeIn } from "./animations/FadeIn";
+import { StaggerContainer, StaggerItem } from "./animations/StaggerContainer";
+
+const stats = [
+  {
+    value: 5000,
+    suffix: "+",
+    label: "Documents Delivered",
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <path d="M16 13H8" />
+        <path d="M16 17H8" />
+      </svg>
+    ),
+  },
+  {
+    value: 450,
+    suffix: "+",
+    label: "Annual Patent Projects",
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="8" r="6" />
+        <path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11" />
+      </svg>
+    ),
+  },
+  {
+    value: 9,
+    suffix: "+",
+    label: "Specialized Industries",
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="4" y="2" width="16" height="20" rx="2" ry="2" />
+        <path d="M8 6h.01" />
+        <path d="M16 6h.01" />
+        <path d="M8 10h8" />
+        <path d="M8 14h8" />
+      </svg>
+    ),
+  },
+  {
+    value: 99.99,
+    suffix: "%",
+    label: "Deadline Compliance",
+    decimals: 2,
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+    ),
+  },
+];
 
 export const DecadeSection = () => {
   return (
+    <section className="relative py-24 md:py-32 overflow-hidden">
+      {/* Background */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            "linear-gradient(135deg, oklch(27% 0.041 260.031) 0%, oklch(35% 0.05 200) 50%, oklch(30% 0.04 60) 100%)",
+        }}
+      />
+      {/* Warm glow */}
+      <div className="absolute top-1/2 right-0 w-[500px] h-[500px] -translate-y-1/2 rounded-full bg-warm/8 blur-[150px]" />
 
-    <div className="hero-section h-full py-8" style={{ background: 'linear-gradient(to top right, oklch(27% 0.041 260.031), oklch(44% 0.043 257.281), oklch(27% 0.046 192.524))' }}>
-      <div className="container mx-auto px-4 md:px-8">
-        <div className="mb-16">
-          <p className="text-xl mb-2 text-slate-300">
-            <Emoji symbol="🎉" className="mr-2" />10th Anniversary<Emoji symbol="🥳" className="ml-2" />
+      {/* Watermark */}
+      <div className="absolute top-1/2 right-8 -translate-y-1/2 text-[20rem] font-bold text-white/[0.03] font-[family-name:var(--font-display)] leading-none select-none hidden lg:block">
+        10+
+      </div>
+
+      <div className="container mx-auto px-8 relative z-10">
+        <FadeIn>
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] mb-4 text-warm">
+            10th Anniversary
           </p>
-          <h2 className="text-4xl font-bold mb-8 text-white">
+        </FadeIn>
+        <FadeIn delay={0.1}>
+          <h2 className="font-[family-name:var(--font-display)] text-4xl md:text-5xl font-bold mb-4 text-white">
             Our Decade of Excellence
           </h2>
-          <p className="text-xl md:text-2xl max-w-3xl leading-relaxed text-white">
+        </FadeIn>
+        <FadeIn delay={0.2}>
+          <p className="text-lg md:text-xl max-w-2xl leading-relaxed text-white/70 mb-16">
             Since 2015 we have been bridging languages and cultures across
             industries with precision and care.
           </p>
-        </div>
+        </FadeIn>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-10">
-          <StatCard
-            value="5000+"
-            label="Documents Delivered"
-            icon={
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                <polyline points="14 2 14 8 20 8" />
-                <path d="M16 13H8" />
-                <path d="M16 17H8" />
-                <path d="M10 9H8" />
-              </svg>
-            }
-          />
-          <StatCard
-            value="450+"
-            label="Annual Patent Projects"
-            icon={
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="8" r="6" />
-                <path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11" />
-              </svg>
-            }
-          />
-          <StatCard
-            value="9+"
-            label="Specialized Industries"
-            icon={
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="4" y="2" width="16" height="20" rx="2" ry="2" />
-                <path d="M9 22v-4h6v4" />
-                <path d="M8 6h.01" />
-                <path d="M16 6h.01" />
-                <path d="M8 10h8" />
-                <path d="M8 14h8" />
-                <path d="M8 18h8" />
-              </svg>
-            }
-          />
-          <StatCard
-            value="99.99%"
-            label="Deadline Compliance"
-            icon={
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10" />
-                <polyline points="12 6 12 12 16 14" />
-              </svg>
-            }
-          />
-        </div>
+        <StaggerContainer className="grid grid-cols-2 lg:grid-cols-4 gap-8">
+          {stats.map((stat) => (
+            <StaggerItem key={stat.label}>
+              <div className="group relative p-6 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 hover:border-warm/30 transition-all duration-300 hover:bg-white/10">
+                <div className="text-warm mb-4 group-hover:scale-110 transition-transform duration-300">
+                  {stat.icon}
+                </div>
+                <div className="text-3xl md:text-4xl font-bold text-white mb-2">
+                  <CountUp
+                    end={stat.value}
+                    suffix={stat.suffix}
+                    decimals={stat.decimals || 0}
+                  />
+                </div>
+                <p className="text-white/50 text-sm font-medium">{stat.label}</p>
+              </div>
+            </StaggerItem>
+          ))}
+        </StaggerContainer>
       </div>
-    </div>
+    </section>
   );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,135 @@
+"use client";
+import Image from "next/image";
+import Link from "next/link";
+
+const serviceLinks = [
+  { label: "Certified Translations", href: "/certified-translations" },
+  { label: "Interpreting", href: "/interpreting" },
+  { label: "Subtitling", href: "/audiovisual-translation" },
+];
+
+const industryLinks = [
+  { label: "Pharmaceutical", href: "/pharmaceutical-translation" },
+  { label: "Maritime", href: "/maritime-translation" },
+  { label: "Academic", href: "/academic-translation" },
+];
+
+const socialLinks = [
+  { label: "Instagram", href: "https://www.instagram.com/afterwordstranslations/", icon: "/insta.svg" },
+  { label: "LinkedIn", href: "https://www.linkedin.com/company/afterwordstranslations/", icon: "/in.png" },
+  { label: "Facebook", href: "https://www.facebook.com/AfterWordstranslations", icon: "/fb.png" },
+];
+
+export const Footer = () => {
+  return (
+    <footer className="bg-slate-900 text-white">
+      {/* Warm gradient divider */}
+      <div className="h-1 bg-gradient-to-r from-warm/0 via-warm to-warm/0" />
+
+      <div className="container mx-auto px-8 py-16">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 mb-16">
+          {/* Brand */}
+          <div>
+            <Image
+              alt="Afterwords logo"
+              src="/logo.svg"
+              width={200}
+              height={50}
+              className="mb-4 w-48"
+            />
+            <p className="text-white/60 text-sm leading-relaxed">
+              Precision in every word. A boutique Greek translation agency bridging languages and cultures since 2015.
+            </p>
+          </div>
+
+          {/* Services */}
+          <div>
+            <h4 className="font-semibold text-sm uppercase tracking-[0.15em] text-warm mb-6">
+              Services
+            </h4>
+            <ul className="space-y-3">
+              {serviceLinks.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className="text-white/60 hover:text-white transition-colors duration-200 text-sm"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Industries */}
+          <div>
+            <h4 className="font-semibold text-sm uppercase tracking-[0.15em] text-warm mb-6">
+              Industries
+            </h4>
+            <ul className="space-y-3">
+              {industryLinks.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className="text-white/60 hover:text-white transition-colors duration-200 text-sm"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+              <li>
+                <Link
+                  href="/blog"
+                  className="text-white/60 hover:text-white transition-colors duration-200 text-sm"
+                >
+                  Blog
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          {/* Connect */}
+          <div>
+            <h4 className="font-semibold text-sm uppercase tracking-[0.15em] text-warm mb-6">
+              Connect
+            </h4>
+            <div className="flex items-center gap-4 mb-6">
+              {socialLinks.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  className="w-10 h-10 rounded-full bg-white/10 flex items-center justify-center hover:bg-warm/20 transition-all duration-300"
+                  aria-label={link.label}
+                >
+                  <Image
+                    alt={link.label}
+                    width={20}
+                    height={20}
+                    src={link.icon}
+                    className="w-4 h-4 opacity-70"
+                  />
+                </a>
+              ))}
+            </div>
+            <button
+              className="text-sm text-warm hover:text-warm-dark transition-colors duration-200 cursor-pointer"
+              onClick={() => window.Beacon("open")}
+            >
+              Get in touch &rarr;
+            </button>
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div className="border-t border-white/10 pt-8 flex flex-col md:flex-row justify-between items-center gap-4">
+          <p className="text-white/40 text-sm">
+            &copy; {new Date().getFullYear()} Afterwords. All rights reserved.
+          </p>
+          <p className="text-white/40 text-sm">
+            Athens, Greece
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+};

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -77,12 +77,26 @@ export const Footer = () => {
                   </Link>
                 </li>
               ))}
+            </ul>
+
+            <h4 className="font-semibold text-sm uppercase tracking-[0.15em] text-warm mb-4 mt-8">
+              Resources
+            </h4>
+            <ul className="space-y-3">
               <li>
                 <Link
                   href="/blog"
                   className="text-white/60 hover:text-white transition-colors duration-200 text-sm"
                 >
                   Blog
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/portfolio"
+                  className="text-white/60 hover:text-white transition-colors duration-200 text-sm"
+                >
+                  Portfolio
                 </Link>
               </li>
             </ul>
@@ -125,6 +139,13 @@ export const Footer = () => {
           <p className="text-white/40 text-sm">
             &copy; {new Date().getFullYear()} Afterwords. All rights reserved.
           </p>
+          <Image
+            alt="I work with SDL Trados Studio"
+            src="/trados.png"
+            width={180}
+            height={40}
+            className="h-7 w-auto opacity-50 hover:opacity-80 transition-opacity duration-300"
+          />
           <p className="text-white/40 text-sm">
             Athens, Greece
           </p>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
 import { ThemeToggle } from "~/components/ThemeToggle";
 
 export interface NavItem {
@@ -17,16 +18,29 @@ export interface HeaderProps {
 
 export function Header({ navItems }: HeaderProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => setScrolled(window.scrollY > 20);
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
   return (
-    <header className="text-gray-100 body-font w-full mb-8">
+    <header
+      className={`text-gray-100 body-font w-full mb-8 sticky top-0 z-50 transition-all duration-300 ${
+        scrolled
+          ? "bg-slate-900/80 backdrop-blur-xl shadow-lg -mx-8 lg:-mx-24 px-8 lg:px-24 py-2"
+          : "py-4"
+      }`}
+    >
       <div className="container mx-auto">
-        <div className="mt-4 flex items-center justify-between gap-4">
+        <div className="flex items-center justify-between gap-4">
           {/* Logo */}
           <Link className="title-font font" href="/">
             <Image
               src="/logo.svg"
-              className="w-40 md:w-48 lg:w-2/3"
+              className={`transition-all duration-300 ${scrolled ? "w-32 md:w-36" : "w-40 md:w-48 lg:w-2/3"}`}
               width={312}
               height={67}
               alt="Afterwords Logo"
@@ -34,11 +48,11 @@ export function Header({ navItems }: HeaderProps) {
           </Link>
 
           {/* Desktop Navigation */}
-          <nav className="hidden md:flex items-center gap-4">
+          <nav className="hidden md:flex items-center gap-6">
             {navItems.map((item) => (
               <a
                 key={item.href}
-                className="text-white py-1 link"
+                className="text-white/80 hover:text-warm text-sm font-medium transition-colors duration-200 py-1"
                 href={item.href}
                 target={item.external ? "_blank" : undefined}
                 rel={item.external ? "noopener noreferrer" : undefined}
@@ -48,51 +62,30 @@ export function Header({ navItems }: HeaderProps) {
             ))}
           </nav>
 
-          {/* Right side: Burger (mobile) / empty (desktop), LinkedIn, Theme Toggle */}
-          <div className="flex items-center gap-2 md:gap-4">
+          {/* Right side */}
+          <div className="flex items-center gap-3">
             {/* Burger Menu - Mobile only */}
             <button
               className="md:hidden text-white p-2"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
               aria-label="Toggle menu"
             >
-              <svg
-                className="w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 {mobileMenuOpen ? (
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 ) : (
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 6h16M4 12h16M4 18h16"
-                  />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
                 )}
               </svg>
             </button>
 
             {/* LinkedIn */}
             <a
-              className="text-white p-1"
+              className="text-white/70 hover:text-warm transition-colors duration-200 p-1"
               href="https://www.linkedin.com/company/afterwordstranslations"
               aria-label="LinkedIn"
             >
-              <Image
-                alt="LinkedIn logo"
-                width={50}
-                height={50}
-                className="w-6"
-                src="/in.png"
-              />
+              <Image alt="LinkedIn logo" width={50} height={50} className="w-5" src="/in.png" />
             </a>
 
             {/* Theme Toggle */}
@@ -101,24 +94,35 @@ export function Header({ navItems }: HeaderProps) {
         </div>
 
         {/* Mobile Menu Dropdown */}
-        {mobileMenuOpen && (
-          <nav className="md:hidden mt-4 pb-4 border-t border-white/20">
-            <div className="flex flex-col gap-2 pt-4">
-              {navItems.map((item) => (
-                <a
-                  key={item.href}
-                  className="text-white py-2 link"
-                  href={item.href}
-                  onClick={() => setMobileMenuOpen(false)}
-                  target={item.external ? "_blank" : undefined}
-                  rel={item.external ? "noopener noreferrer" : undefined}
-                >
-                  {item.label}
-                </a>
-              ))}
-            </div>
-          </nav>
-        )}
+        <AnimatePresence>
+          {mobileMenuOpen && (
+            <motion.nav
+              className="md:hidden mt-4 pb-4 border-t border-white/10"
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <div className="flex flex-col gap-1 pt-4">
+                {navItems.map((item, i) => (
+                  <motion.a
+                    key={item.href}
+                    className="text-white/80 hover:text-warm py-2 text-sm font-medium transition-colors duration-200"
+                    href={item.href}
+                    onClick={() => setMobileMenuOpen(false)}
+                    target={item.external ? "_blank" : undefined}
+                    rel={item.external ? "noopener noreferrer" : undefined}
+                    initial={{ opacity: 0, x: -10 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ delay: i * 0.05 }}
+                  >
+                    {item.label}
+                  </motion.a>
+                ))}
+              </div>
+            </motion.nav>
+          )}
+        </AnimatePresence>
       </div>
     </header>
   );

--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -1,0 +1,103 @@
+"use client";
+import { ReactNode } from "react";
+import { motion } from "framer-motion";
+import { Header } from "./Header";
+
+interface PageHeroProps {
+  navItems: { label: string; href: string }[];
+  badge: string;
+  title: string;
+  subtitle: string;
+  cta?: ReactNode;
+  features?: { title: string; description: string }[];
+  backgroundElement?: ReactNode;
+  variant?: "full" | "compact";
+  className?: string;
+}
+
+export const PageHero = ({
+  navItems,
+  badge,
+  title,
+  subtitle,
+  cta,
+  features,
+  backgroundElement,
+  variant = "compact",
+  className = "",
+}: PageHeroProps) => {
+  const paddingClass = variant === "full" ? "pb-20" : "pb-16";
+
+  return (
+    <section className={`relative w-full overflow-hidden ${className}`}>
+      {/* Background */}
+      {backgroundElement || (
+        <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-primary to-slate-900" />
+      )}
+
+      <div className={`relative z-10 px-8 lg:px-24 ${paddingClass}`}>
+        <Header navItems={navItems} />
+
+        <div className="max-w-2xl mt-8">
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <span className="inline-block text-xs font-semibold uppercase tracking-[0.15em] px-4 py-2 rounded-full bg-warm/20 text-warm border border-warm/30 mb-8">
+              {badge}
+            </span>
+          </motion.div>
+
+          <motion.h1
+            className="font-[family-name:var(--font-display)] text-4xl md:text-5xl lg:text-6xl leading-tight font-bold mb-6 text-white"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+          >
+            {title}
+          </motion.h1>
+
+          <motion.p
+            className="text-lg md:text-xl text-white/80 mb-10 leading-relaxed max-w-xl"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+          >
+            {subtitle}
+          </motion.p>
+
+          {cta && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.3 }}
+            >
+              {cta}
+            </motion.div>
+          )}
+        </div>
+
+        {features && features.length > 0 && (
+          <motion.div
+            className="grid grid-cols-1 gap-6 md:grid-cols-3 mt-16 pt-8 border-t border-white/10"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.4 }}
+          >
+            {features.map((feature, i) => (
+              <div key={i} className="group">
+                <h4 className="text-sm font-semibold uppercase tracking-wider text-warm mb-2">
+                  {feature.title}
+                </h4>
+                <p className="text-white/60 text-sm leading-relaxed">
+                  {feature.description}
+                </p>
+              </div>
+            ))}
+          </motion.div>
+        )}
+      </div>
+    </section>
+  );
+};

--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -32,71 +32,77 @@ export const PageHero = ({
     <section className={`relative w-full overflow-hidden ${className}`}>
       {/* Background */}
       {backgroundElement || (
-        <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-primary to-slate-900" />
+        <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900" />
       )}
 
       <div className={`relative z-10 px-8 lg:px-24 ${paddingClass}`}>
         <Header navItems={navItems} />
 
-        <div className="max-w-2xl mt-8">
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-          >
-            <span className="inline-block text-xs font-semibold uppercase tracking-[0.15em] px-4 py-2 rounded-full bg-warm/20 text-warm border border-warm/30 mb-8">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-20 mt-8 items-start">
+          {/* Left — title */}
+          <div>
+            <motion.p
+              className="text-sm font-semibold uppercase tracking-[0.2em] mb-6 text-warm"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+            >
               {badge}
-            </span>
-          </motion.div>
+            </motion.p>
 
-          <motion.h1
-            className="font-[family-name:var(--font-display)] text-4xl md:text-5xl lg:text-6xl leading-tight font-bold mb-6 text-white"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.1 }}
-          >
-            {title}
-          </motion.h1>
-
-          <motion.p
-            className="text-lg md:text-xl text-white/80 mb-10 leading-relaxed max-w-xl"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.2 }}
-          >
-            {subtitle}
-          </motion.p>
-
-          {cta && (
-            <motion.div
+            <motion.h1
+              className="font-[family-name:var(--font-display)] text-4xl md:text-5xl lg:text-6xl leading-tight font-bold text-white"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.3 }}
+              transition={{ duration: 0.6, delay: 0.1 }}
             >
-              {cta}
-            </motion.div>
-          )}
-        </div>
+              {title}
+            </motion.h1>
+          </div>
 
-        {features && features.length > 0 && (
-          <motion.div
-            className="grid grid-cols-1 gap-6 md:grid-cols-3 mt-16 pt-8 border-t border-white/10"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.4 }}
-          >
-            {features.map((feature, i) => (
-              <div key={i} className="group">
-                <h4 className="text-sm font-semibold uppercase tracking-wider text-warm mb-2">
-                  {feature.title}
-                </h4>
-                <p className="text-white/60 text-sm leading-relaxed">
-                  {feature.description}
-                </p>
-              </div>
-            ))}
-          </motion.div>
-        )}
+          {/* Right — subtitle, CTA, features */}
+          <div className="flex flex-col justify-center">
+            <motion.p
+              className="text-lg md:text-xl text-white/80 mb-8 leading-relaxed"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.2 }}
+            >
+              {subtitle}
+            </motion.p>
+
+            {cta && (
+              <motion.div
+                className="mb-10"
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.3 }}
+              >
+                {cta}
+              </motion.div>
+            )}
+
+            {features && features.length > 0 && (
+              <motion.div
+                className="space-y-4 pt-8 border-t border-white/10"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ duration: 0.6, delay: 0.4 }}
+              >
+                {features.map((feature, i) => (
+                  <div key={i} className="border-l-2 border-warm/40 pl-4">
+                    <h4 className="text-sm font-semibold uppercase tracking-wider text-warm mb-1">
+                      {feature.title}
+                    </h4>
+                    <p className="text-white/50 text-sm leading-relaxed">
+                      {feature.description}
+                    </p>
+                  </div>
+                ))}
+              </motion.div>
+            )}
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -37,9 +37,6 @@ export const SectionHeader = ({
           {titleItalic && <em className="font-normal"> {titleItalic}</em>}
         </h2>
       </FadeIn>
-      <FadeIn delay={0.1}>
-        <div className={`w-16 h-1 rounded-full bg-warm mb-6 ${align === "center" ? "mx-auto" : ""}`} />
-      </FadeIn>
       {description && (
         <FadeIn delay={0.2}>
           <p className={`text-lg md:text-xl leading-relaxed ${light ? "text-white/80" : "text-base-content/70"}`}>

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { FadeIn } from "./animations/FadeIn";
+
+interface SectionHeaderProps {
+  eyebrow: string;
+  title: string;
+  titleItalic?: string;
+  description?: string;
+  align?: "left" | "center";
+  light?: boolean;
+  className?: string;
+}
+
+export const SectionHeader = ({
+  eyebrow,
+  title,
+  titleItalic,
+  description,
+  align = "left",
+  light = false,
+  className = "",
+}: SectionHeaderProps) => {
+  const alignClass = align === "center" ? "text-center mx-auto" : "";
+  const textColor = light ? "text-white" : "text-base-content";
+  const mutedColor = light ? "text-white/60" : "text-warm-dark";
+
+  return (
+    <div className={`max-w-3xl ${alignClass} ${className}`}>
+      <FadeIn>
+        <p className={`text-sm font-semibold uppercase tracking-[0.2em] mb-4 ${mutedColor}`}>
+          {eyebrow}
+        </p>
+      </FadeIn>
+      <FadeIn delay={0.1}>
+        <h2 className={`font-[family-name:var(--font-display)] text-4xl md:text-5xl font-bold mb-6 leading-tight ${textColor}`}>
+          {title}
+          {titleItalic && <em className="font-normal"> {titleItalic}</em>}
+        </h2>
+      </FadeIn>
+      <FadeIn delay={0.1}>
+        <div className={`w-16 h-1 rounded-full bg-warm mb-6 ${align === "center" ? "mx-auto" : ""}`} />
+      </FadeIn>
+      {description && (
+        <FadeIn delay={0.2}>
+          <p className={`text-lg md:text-xl leading-relaxed ${light ? "text-white/80" : "text-base-content/70"}`}>
+            {description}
+          </p>
+        </FadeIn>
+      )}
+    </div>
+  );
+};

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { FadeIn } from "./animations/FadeIn";
+import { SectionHeader } from "./SectionHeader";
 
 const testimonials = [
   {
@@ -65,30 +65,31 @@ export const TestimonialsSection = () => {
   const testimonial = testimonials[current];
 
   return (
-    <section className="py-24 md:py-32 bg-base-300/50">
+    <section className="py-24 md:py-32 bg-base-200">
       <div className="container mx-auto px-8">
-        <FadeIn>
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] mb-4 text-warm-dark">
-            Client Testimonials
-          </p>
-        </FadeIn>
-        <FadeIn delay={0.1}>
-          <h2 className="font-[family-name:var(--font-display)] text-4xl md:text-5xl font-bold mb-16 text-base-content">
-            What our clients say
-          </h2>
-        </FadeIn>
+        <SectionHeader
+          eyebrow="Client Testimonials"
+          title="What our clients say"
+          className="mb-16"
+        />
 
         <div
           className="relative max-w-4xl"
           onMouseEnter={() => setIsPaused(true)}
           onMouseLeave={() => setIsPaused(false)}
         >
-          {/* Decorative quote mark */}
-          <div className="absolute -top-8 -left-4 text-[8rem] leading-none font-[family-name:var(--font-display)] text-warm/15 select-none hidden md:block">
+          {/* Decorative quote mark — animates on slide change */}
+          <motion.div
+            key={`quote-${current}`}
+            className="absolute -top-2 -left-2 md:-left-6 text-[6rem] md:text-[8rem] leading-none font-[family-name:var(--font-display)] text-warm/15 select-none pointer-events-none"
+            initial={{ opacity: 0, scale: 0.3, y: 30 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            transition={{ type: "spring", stiffness: 200, damping: 15, mass: 0.8 }}
+          >
             &ldquo;
-          </div>
+          </motion.div>
 
-          <div className="relative min-h-[280px] md:min-h-[200px]">
+          <div className="relative min-h-[280px] md:min-h-[200px] pt-12 md:pt-16">
             <AnimatePresence mode="wait">
               <motion.div
                 key={current}
@@ -98,7 +99,7 @@ export const TestimonialsSection = () => {
                 transition={{ duration: 0.5 }}
               >
                 <blockquote className="font-[family-name:var(--font-display)] text-xl md:text-2xl leading-relaxed text-base-content/80 mb-8 italic">
-                  &ldquo;{testimonial.quote}&rdquo;
+                  {testimonial.quote}
                 </blockquote>
                 <div className="flex items-center gap-4">
                   <div className="w-12 h-[2px] bg-warm rounded-full" />

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -1,79 +1,137 @@
-import { TestimonialCard } from "./TestimonialCard";
+"use client";
+import { useState, useEffect, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { FadeIn } from "./animations/FadeIn";
+
+const testimonials = [
+  {
+    quote:
+      "In 2023, the year when the title of the European Capital of Culture was awarded, 2023 Eleusis in cooperation with the Aikaterini Laskaridis Foundation and with its exclusive sponsorship, implemented the dedicated bilingual anthology They Wrote about Her with texts by Greek and foreign authors written about Eleusis, from antiquity to the present day. The Afterwords Translations team undertook the difficult task of translating texts from the entire range of this anthology. The collaboration was flawless at every level and the result was excellent with an emphasis on the quality of the style and meaning of the texts.",
+    author: "Isavela Karouti",
+    company: "2023 Eleusis European Capital of Culture",
+  },
+  {
+    quote:
+      "I strongly endorse Ms. Chatzistylianou as a subtitler. She is professional, reliable, and fast, with excellent knowledge of multiple languages, strong research abilities, and clear communication. Her expertise and work ethic make her one of the best in today's subtitling market.",
+    author: "Georgios Kalipetis",
+    company: "VIDEOPRESS S.A.",
+  },
+  {
+    quote:
+      "Beyond their linguistic expertise, Afterwords Translations proves to be a collaborative and reliable team. They consistently go above and beyond to meet deadlines and play a crucial role in the overall success of our projects, especially focusing on chemical and technical patents.",
+    author: "Olena Vasilatos",
+    company: "LSP Owner & Translator",
+  },
+  {
+    quote:
+      "After working with Afterwords Translations, I can confidently affirm their outstanding proficiency in medical and legal translations. Their precision, unwavering professionalism, and dedication to meeting deadlines make them an indispensable resource.",
+    author: "Sofia Simoni",
+    company: "Greek LSP Owner & Subtitler",
+  },
+  {
+    quote:
+      "The Afterwords Translations team is dedicated and readily accessible to deliver outstanding services for translation and interpreting requirements. Moreover, they exhibit a high level of professionalism and ethical conduct, making them excellent colleagues. I wholeheartedly recommend their services.",
+    author: "Zoe Resta, Ph.D.",
+    company: "Translator & Conference Interpreter",
+  },
+  {
+    quote:
+      "We engaged Afterwords Translations for a high-stakes interpretation project and they delivered at a level few vendors reach. They were professional and strong on context, not just language. Communication was clear, controlled, and seamless throughout. I would work with them again without hesitation.",
+    author: "Ifigenia Geiveli",
+    company: "Human Resources Executive",
+  },
+  {
+    quote:
+      "Our long-standing collaboration with Afterwords proves the quality of their work. They are a team of translators who respond with great success to the translation of texts from various scientific disciplines, always respecting the deadlines set each time.",
+    author: "Maria Simantiri",
+    company: "Gutenberg Editions, Athens",
+  },
+];
 
 export const TestimonialsSection = () => {
-  const testimonials = [
-    {
-      quote:
-        "In 2023, the year when the title of the European Capital of Culture was awarded, 2023 Eleusis in cooperation with the Aikaterini Laskaridis Foundation and with its exclusive sponsorship, implemented the dedicated bilingual anthology They Wrote about Her with texts by Greek and foreign authors written about Eleusis, from antiquity to the present day. The Afterwords Translations team undertook the difficult task of translating texts from the entire range of this anthology. The collaboration was flawless at every level and the result was excellent with an emphasis on the quality of the style and meaning of the texts.",
-      author: "Isavela Karouti",
-      company: "2023 Eleusis European Capital of Culture",
-      featured: true,
-    },
-    {
-      quote:
-        "I strongly endorse Ms. Chatzistylianou as a subtitler. She is professional, reliable, and fast, with excellent knowledge of multiple languages, strong research abilities, and clear communication. Her expertise and work ethic make her one of the best in today's subtitling market.",
-      author: "Georgios Kalipetis",
-      company: "VIDEOPRESS S.A.",
-    },
-    {
-      quote:
-        "Beyond their linguistic expertise, Afterwords Translations proves to be a collaborative and reliable team. They consistently go above and beyond to meet deadlines and play a crucial role in the overall success of our projects, especially focusing on chemical and technical patents.",
-      author: "Olena Vasilatos",
-      company: "LSP Owner & Translator",
-    },
-    {
-      quote:
-        "After working with Afterwords Translations, I can confidently affirm their outstanding proficiency in medical and legal translations. Their precision, unwavering professionalism, and dedication to meeting deadlines make them an indispensable resource.",
-      author: "Sofia Simoni",
-      company: "Greek LSP Owner & Subtitler",
-    },
-    {
-      quote:
-        "The Afterwords Translations team is dedicated and readily accessible to deliver outstanding services for translation and interpreting requirements. Moreover, they exhibit a high level of professionalism and ethical conduct, making them excellent colleagues. I wholeheartedly recommend their services.",
-      author: "Zoe Resta, Ph.D.",
-      company: "Translator & Conference Interpreter",
-    },
-    {
-      quote:
-        "We engaged Afterwords Translations for a high-stakes interpretation project and they delivered at a level few vendors reach. They were professional and strong on context, not just language. Communication was clear, controlled, and seamless throughout. I would work with them again without hesitation.",
-      author: "Ifigenia Geiveli",
-      company: "Human Resources Executive",
-    },
-    {
-      quote:
-        "Our long-standing collaboration with Afterwords proves the quality of their work. They are a team of translators who respond with great success to the translation of texts from various scientific disciplines, always respecting the deadlines set each time.",
-      author: "Maria Simantiri",
-      company: "Gutenberg Editions, Athens",
-    },
-  ];
+  const [current, setCurrent] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+
+  const next = useCallback(() => {
+    setCurrent((prev) => (prev + 1) % testimonials.length);
+  }, []);
+
+  useEffect(() => {
+    if (isPaused) return;
+    const timer = setInterval(next, 7000);
+    return () => clearInterval(timer);
+  }, [isPaused, next]);
+
+  const testimonial = testimonials[current];
 
   return (
-    <div className="py-16">
-      <div className="container mx-auto px-4 md:px-8">
-        <div className="mb-12">
-          <p className="text-2xl mb-2 text-slate-300">
-            Client testimonials
+    <section className="py-24 md:py-32 bg-base-300/50">
+      <div className="container mx-auto px-8">
+        <FadeIn>
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] mb-4 text-warm-dark">
+            Client Testimonials
           </p>
-          <h2 className="text-4xl md:text-5xl font-bold text-white">
+        </FadeIn>
+        <FadeIn delay={0.1}>
+          <h2 className="font-[family-name:var(--font-display)] text-4xl md:text-5xl font-bold mb-16 text-base-content">
             What our clients say
           </h2>
-        </div>
+        </FadeIn>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {testimonials.map((testimonial, index) => (
-            <div
-              key={index}
-              className={testimonial.featured ? "md:col-span-3" : ""}
-            >
-              <TestimonialCard
-                quote={testimonial.quote}
-                author={testimonial.author}
-                company={testimonial.company}
+        <div
+          className="relative max-w-4xl"
+          onMouseEnter={() => setIsPaused(true)}
+          onMouseLeave={() => setIsPaused(false)}
+        >
+          {/* Decorative quote mark */}
+          <div className="absolute -top-8 -left-4 text-[8rem] leading-none font-[family-name:var(--font-display)] text-warm/15 select-none hidden md:block">
+            &ldquo;
+          </div>
+
+          <div className="relative min-h-[280px] md:min-h-[200px]">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={current}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.5 }}
+              >
+                <blockquote className="font-[family-name:var(--font-display)] text-xl md:text-2xl leading-relaxed text-base-content/80 mb-8 italic">
+                  &ldquo;{testimonial.quote}&rdquo;
+                </blockquote>
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-[2px] bg-warm rounded-full" />
+                  <div>
+                    <p className="font-bold text-base-content">
+                      {testimonial.author}
+                    </p>
+                    <p className="text-sm text-base-content/50">
+                      {testimonial.company}
+                    </p>
+                  </div>
+                </div>
+              </motion.div>
+            </AnimatePresence>
+          </div>
+
+          {/* Navigation dots */}
+          <div className="flex gap-2 mt-12">
+            {testimonials.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setCurrent(i)}
+                className={`h-2 rounded-full transition-all duration-300 cursor-pointer ${
+                  i === current
+                    ? "w-8 bg-warm"
+                    : "w-2 bg-base-content/20 hover:bg-base-content/40"
+                }`}
+                aria-label={`Go to testimonial ${i + 1}`}
               />
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 };

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -116,19 +116,29 @@ export const TestimonialsSection = () => {
             </AnimatePresence>
           </div>
 
-          {/* Navigation dots */}
+          {/* Navigation dots with progress indicator */}
           <div className="flex gap-2 mt-12">
             {testimonials.map((_, i) => (
               <button
                 key={i}
                 onClick={() => setCurrent(i)}
-                className={`h-2 rounded-full transition-all duration-300 cursor-pointer ${
+                className={`relative h-2 rounded-full cursor-pointer overflow-hidden transition-all duration-300 ${
                   i === current
-                    ? "w-8 bg-warm"
+                    ? "w-8 bg-warm/30"
                     : "w-2 bg-base-content/20 hover:bg-base-content/40"
                 }`}
                 aria-label={`Go to testimonial ${i + 1}`}
-              />
+              >
+                {i === current && (
+                  <motion.div
+                    className="absolute inset-0 bg-warm rounded-full origin-left"
+                    initial={{ scaleX: 0 }}
+                    animate={{ scaleX: isPaused ? undefined : 1 }}
+                    transition={{ duration: 7, ease: "linear" }}
+                    key={`progress-${current}`}
+                  />
+                )}
+              </button>
             ))}
           </div>
         </div>

--- a/src/components/Translator.tsx
+++ b/src/components/Translator.tsx
@@ -22,56 +22,51 @@ export default function Translator({
 }: TranslatorProps) {
   return (
     <motion.div
-      className="group relative bg-base-100 rounded-2xl border border-base-300 p-6 md:p-8 shadow-sm hover:shadow-xl transition-all duration-500"
-      style={{ marginTop: index > 0 ? "-1rem" : 0, zIndex: 10 - index }}
+      className="card-surface group relative rounded-2xl border border-base-300 p-6 md:p-8 hover:shadow-xl hover:-translate-y-1 transition-all duration-500 h-full flex flex-col"
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.5, delay: index * 0.15 }}
     >
-      <div className="flex flex-col md:flex-row gap-6 items-start">
-        <div className="relative shrink-0">
-          <Image
-            src={imageSrc}
-            alt={fullName}
-            width={120}
-            height={120}
-            className="rounded-xl w-24 h-24 md:w-28 md:h-28 object-cover"
-          />
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="absolute -bottom-2 -right-2 w-8 h-8 bg-[#0077b5] rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-200 shadow-lg"
-            aria-label={`${fullName} on LinkedIn`}
-          >
-            <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-            </svg>
-          </a>
-        </div>
-
-        <div className="flex-1">
-          <h3 className="font-[family-name:var(--font-display)] text-xl md:text-2xl font-bold mb-2 text-base-content">
-            {fullName}
-          </h3>
-          <p className="text-base-content/70 text-base leading-relaxed mb-4">
-            {description}
-          </p>
-          {specializations.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {specializations.map((spec) => (
-                <span
-                  key={spec}
-                  className="text-xs font-medium px-3 py-1 rounded-full bg-warm/10 text-warm-dark border border-warm/20"
-                >
-                  {spec}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
+      <div className="relative mb-5 self-start">
+        <Image
+          src={imageSrc}
+          alt={fullName}
+          width={160}
+          height={160}
+          className="rounded-xl w-20 h-20 md:w-24 md:h-24 object-cover"
+        />
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="absolute -bottom-2 -right-2 w-7 h-7 bg-[#0077b5] rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-200 shadow-lg"
+          aria-label={`${fullName} on LinkedIn`}
+        >
+          <svg className="w-3.5 h-3.5 text-white" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+          </svg>
+        </a>
       </div>
+
+      <h3 className="font-[family-name:var(--font-display)] text-xl font-bold mb-2 text-base-content">
+        {fullName}
+      </h3>
+      <p className="text-base-content/70 text-sm leading-relaxed mb-4 flex-1">
+        {description}
+      </p>
+      {specializations.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {specializations.map((spec) => (
+            <span
+              key={spec}
+              className="text-xs font-medium px-3 py-1 rounded-full bg-warm/10 text-warm-dark border border-warm/20"
+            >
+              {spec}
+            </span>
+          ))}
+        </div>
+      )}
     </motion.div>
   );
 }

--- a/src/components/Translator.tsx
+++ b/src/components/Translator.tsx
@@ -1,36 +1,77 @@
+"use client";
 import Image from "next/image";
+import { motion } from "framer-motion";
+
 type TranslatorProps = {
   fullName: string;
   shortName: string;
   imageSrc: string;
   href: string;
   description: string;
+  specializations?: string[];
+  index?: number;
 };
-export default function Translator(props: TranslatorProps) {
+
+export default function Translator({
+  fullName,
+  imageSrc,
+  href,
+  description,
+  specializations = [],
+  index = 0,
+}: TranslatorProps) {
   return (
-    <div className="rounded mb-8 grid gap-4 grid-cols-4">
-      <figure className="col-span-1">
-        <Image
-          src={props.imageSrc}
-          alt={props.fullName}
-          width={100}
-          height={100}
-          className="rounded-xl w-full"
-        />
-      </figure>
-      <div className="col-span-3 block px-4">
-        <h3 className="card-title text-2xl mb-4">{props.fullName}</h3>
-        <p className="mb-4 text-base">{props.description}</p>
-        <p className="text-base mb-2">Find {props.shortName} on </p>
-        <a href={props.href} className="btn btn-accent px-4" target="_blank">
+    <motion.div
+      className="group relative bg-base-100 rounded-2xl border border-base-300 p-6 md:p-8 shadow-sm hover:shadow-xl transition-all duration-500"
+      style={{ marginTop: index > 0 ? "-1rem" : 0, zIndex: 10 - index }}
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5, delay: index * 0.15 }}
+    >
+      <div className="flex flex-col md:flex-row gap-6 items-start">
+        <div className="relative shrink-0">
           <Image
-            src="/LI-Logo.png"
-            alt="LinkedIn logo"
-            width={80}
-            height={80}
+            src={imageSrc}
+            alt={fullName}
+            width={120}
+            height={120}
+            className="rounded-xl w-24 h-24 md:w-28 md:h-28 object-cover"
           />
-        </a>
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="absolute -bottom-2 -right-2 w-8 h-8 bg-[#0077b5] rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-200 shadow-lg"
+            aria-label={`${fullName} on LinkedIn`}
+          >
+            <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+            </svg>
+          </a>
+        </div>
+
+        <div className="flex-1">
+          <h3 className="font-[family-name:var(--font-display)] text-xl md:text-2xl font-bold mb-2 text-base-content">
+            {fullName}
+          </h3>
+          <p className="text-base-content/70 text-base leading-relaxed mb-4">
+            {description}
+          </p>
+          {specializations.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {specializations.map((spec) => (
+                <span
+                  key={spec}
+                  className="text-xs font-medium px-3 py-1 rounded-full bg-warm/10 text-warm-dark border border-warm/20"
+                >
+                  {spec}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/animations/CountUp.tsx
+++ b/src/components/animations/CountUp.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { useInView } from "framer-motion";
+
+interface CountUpProps {
+  end: number;
+  suffix?: string;
+  prefix?: string;
+  duration?: number;
+  decimals?: number;
+  className?: string;
+}
+
+export const CountUp = ({
+  end,
+  suffix = "",
+  prefix = "",
+  duration = 2,
+  decimals = 0,
+  className = "",
+}: CountUpProps) => {
+  const ref = useRef<HTMLSpanElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-80px" });
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!isInView) return;
+
+    let startTime: number;
+    let animationFrame: number;
+
+    const animate = (timestamp: number) => {
+      if (!startTime) startTime = timestamp;
+      const progress = Math.min((timestamp - startTime) / (duration * 1000), 1);
+      const eased = 1 - Math.pow(1 - progress, 3); // ease-out cubic
+      setCount(eased * end);
+
+      if (progress < 1) {
+        animationFrame = requestAnimationFrame(animate);
+      }
+    };
+
+    animationFrame = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationFrame);
+  }, [isInView, end, duration]);
+
+  return (
+    <span ref={ref} className={className}>
+      {prefix}
+      {count.toFixed(decimals)}
+      {suffix}
+    </span>
+  );
+};

--- a/src/components/animations/FadeIn.tsx
+++ b/src/components/animations/FadeIn.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { motion } from "framer-motion";
+import { ReactNode } from "react";
+
+interface FadeInProps {
+  children: ReactNode;
+  direction?: "up" | "down" | "left" | "right";
+  delay?: number;
+  duration?: number;
+  className?: string;
+}
+
+const directionOffset = {
+  up: { y: 40 },
+  down: { y: -40 },
+  left: { x: 40 },
+  right: { x: -40 },
+};
+
+export const FadeIn = ({
+  children,
+  direction = "up",
+  delay = 0,
+  duration = 0.6,
+  className = "",
+}: FadeInProps) => {
+  const offset = directionOffset[direction];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, ...offset }}
+      whileInView={{ opacity: 1, x: 0, y: 0 }}
+      viewport={{ once: true, margin: "-80px" }}
+      transition={{ duration, delay, ease: [0.25, 0.1, 0.25, 1] }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+};

--- a/src/components/animations/StaggerContainer.tsx
+++ b/src/components/animations/StaggerContainer.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { motion } from "framer-motion";
+import { ReactNode } from "react";
+
+interface StaggerContainerProps {
+  children: ReactNode;
+  staggerDelay?: number;
+  className?: string;
+}
+
+export const StaggerContainer = ({
+  children,
+  staggerDelay = 0.1,
+  className = "",
+}: StaggerContainerProps) => {
+  return (
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: "-80px" }}
+      variants={{
+        hidden: {},
+        visible: { transition: { staggerChildren: staggerDelay } },
+      }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export const StaggerItem = ({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) => {
+  return (
+    <motion.div
+      variants={{
+        hidden: { opacity: 0, y: 30 },
+        visible: {
+          opacity: 1,
+          y: 0,
+          transition: { duration: 0.5, ease: [0.25, 0.1, 0.25, 1] },
+        },
+      }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+};

--- a/src/components/animations/TextReveal.tsx
+++ b/src/components/animations/TextReveal.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { motion } from "framer-motion";
+
+interface TextRevealProps {
+  text: string;
+  className?: string;
+  delay?: number;
+  as?: "h1" | "h2" | "h3" | "p";
+}
+
+export const TextReveal = ({
+  text,
+  className = "",
+  delay = 0,
+  as: Tag = "h1",
+}: TextRevealProps) => {
+  const words = text.split(" ");
+
+  return (
+    <Tag className={className}>
+      <motion.span
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        variants={{
+          hidden: {},
+          visible: { transition: { staggerChildren: 0.08, delayChildren: delay } },
+        }}
+        className="inline"
+      >
+        {words.map((word, i) => (
+          <motion.span
+            key={i}
+            variants={{
+              hidden: { opacity: 0, y: 20, filter: "blur(4px)" },
+              visible: {
+                opacity: 1,
+                y: 0,
+                filter: "blur(0px)",
+                transition: { duration: 0.4, ease: [0.25, 0.1, 0.25, 1] },
+              },
+            }}
+            className="inline-block mr-[0.3em]"
+          >
+            {word}
+          </motion.span>
+        ))}
+      </motion.span>
+    </Tag>
+  );
+};


### PR DESCRIPTION
## Summary
- Refine homepage layout and content structure
- Simplify portfolio page
- Polish `PageHero`, `Translator`, `CTASection`, `DecadeSection`, and `TestimonialsSection` components
- Update global CSS and `SectionHeader`
- Includes all changes from iteration 1

## Preview
This is iteration 2 of the design overhaul — compare with iterations 1 and 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)